### PR TITLE
Don't die if running git fails

### DIFF
--- a/src/nemo_run/core/execution/docker.py
+++ b/src/nemo_run/core/execution/docker.py
@@ -182,13 +182,16 @@ class DockerExecutor(Executor):
     def package(self, packager: Packager, job_name: str):
         assert self.experiment_id, "Executor not assigned to an experiment."
         if isinstance(packager, GitArchivePackager):
-            output = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                check=True,
-                stdout=subprocess.PIPE,
-            )
-            path = output.stdout.splitlines()[0].decode()
-            base_path = Path(path).absolute()
+            try:
+                output = subprocess.run(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                )
+                path = output.stdout.splitlines()[0].decode()
+                base_path = Path(path).absolute()
+            except subprocess.CalledProcessError:
+                base_path = Path(os.getcwd()).absolute()
         else:
             base_path = Path(os.getcwd()).absolute()
         local_pkg = packager.package(base_path, self.job_dir, job_name)

--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -532,13 +532,16 @@ class SlurmExecutor(Executor):
 
         assert self.experiment_id, "Executor not assigned to an experiment."
         if isinstance(packager, GitArchivePackager):
-            output = subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                check=True,
-                stdout=subprocess.PIPE,
-            )
-            path = output.stdout.splitlines()[0].decode()
-            base_path = Path(path).absolute()
+            try:
+                output = subprocess.run(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                )
+                path = output.stdout.splitlines()[0].decode()
+                base_path = Path(path).absolute()
+            except subprocess.CalledProcessError:
+                base_path = Path(os.getcwd()).absolute()
         else:
             base_path = Path(os.getcwd()).absolute()
 


### PR DESCRIPTION
Attempt to fix


```
        git config --global --add safe.directory /mnt/4tb/nemo_ux_mixtral_e2e/e2e/end-to-end-examples
[20:28:50] Error running task mixtral-8x7b: Command '['git', 'rev-parse', '--show-toplevel']' returned non-zero exit status 128.                                                                                                                                                                  experiment.py:623
           Traceback (most recent call last):                                                                                                                                                                                                                                                     experiment.py:624
              File "/mnt/4tb/nemo_ux_nemo_mistral/e2e/NeMo-Run/src/nemo_run/run/experiment.py", line 616, in run
               job.launch(wait=wait, runner=self._runner)
              File "/mnt/4tb/nemo_ux_nemo_mistral/e2e/NeMo-Run/src/nemo_run/run/job.py", line 126, in launch
               self.handle, status = launch(
              File "/mnt/4tb/nemo_ux_nemo_mistral/e2e/NeMo-Run/src/nemo_run/run/torchx_backend/launcher.py", line 99, in launch
               app_handle = runner.run(
              File "/mnt/4tb/nemo_ux_nemo_mistral/e2e/NeMo-Run/src/nemo_run/run/torchx_backend/runner.py", line 87, in run
               handle = self.schedule(dryrun_info)
              File "/mnt/4tb/nemo_ux_nemo_mistral/e2e/NeMo-Run/src/nemo_run/run/torchx_backend/runner.py", line 102, in schedule
               app_id = sched.schedule(dryrun_info)
              File "/mnt/4tb/nemo_ux_nemo_mistral/e2e/NeMo-Run/src/nemo_run/run/torchx_backend/schedulers/slurm.py", line 151, in schedule
               slurm_cfg.package(packager=slurm_cfg.packager, job_name=Path(job_dir).name)
              File "/mnt/4tb/nemo_ux_nemo_mistral/e2e/NeMo-Run/src/nemo_run/core/execution/slurm.py", line 535, in package
               output = subprocess.run(
              File "/usr/lib/python3.10/subprocess.py", line 526, in run
               raise CalledProcessError(retcode, process.args,
            subprocess.CalledProcessError: Command '['git', 'rev-parse', '--show-toplevel']' returned non-zero exit status 128.
```