### PR TITLE
Do not deserialize task cfg in _load_jobs

### DIFF
--- a/src/nemo_run/run/experiment.py
+++ b/src/nemo_run/run/experiment.py
@@ -343,9 +343,6 @@ nemo experiment cancel {exp_id} 0
         for job_cfg, task_cfg in serialized_jobs:
             job_cfg = serializer.deserialize(job_cfg)
 
-            if isinstance(task_cfg, str):
-                task_cfg = serializer.deserialize(task_cfg)
-
             job: Job | JobGroup = fdl.build(job_cfg)
             if isinstance(job, Job):
                 job.task = task_cfg  # type: ignore


### PR DESCRIPTION
Deserializing task_cfg is only needed for `exp.reset`.