### PR TITLE
Use rsync to sync experiment directory for slurm

### DIFF
--- a/src/nemo_run/core/tunnel/client.py
+++ b/src/nemo_run/core/tunnel/client.py
@@ -223,7 +223,6 @@ class SSHTunnel(Tunnel):
     def connect(self):
         if not (self.session and self.session.is_connected):
             self._authenticate()
-            self._check_shell()
 
     def _check_connect(self):
         if not (self.session and self.session.is_connected):
@@ -263,7 +262,7 @@ class SSHTunnel(Tunnel):
             self.host,
             user=self.user,
             connect_kwargs=connect_kwargs,
-            forward_agent=True,
+            forward_agent=False,
             config=config,
         )
         logger.debug(
@@ -301,20 +300,6 @@ class SSHTunnel(Tunnel):
         if not self.session.is_connected:
             sys.exit(1)
         logger.debug(":white_check_mark: The client is authenticated successfully")
-
-    def _check_shell(self):
-        logger.debug("Verifying shell location")
-        assert self.session, "session is not yet established."
-
-        if self.shell is None:
-            shell = self.session.run("echo $SHELL || echo $0", hide=True).stdout.strip()
-            if not shell:
-                raise ValueError("Could not determine shell. Please specify one using --shell.")
-            self.shell = shell
-        else:
-            # Get the full path to the shell in case the user specified a shell name
-            self.shell = self.session.run(f"which {self.shell}", hide=True).stdout.strip()
-        logger.debug(f":white_check_mark: Using shell: {self.shell}")
 
 
 class SSHConfigFile:

--- a/src/nemo_run/core/tunnel/rsync.py
+++ b/src/nemo_run/core/tunnel/rsync.py
@@ -89,6 +89,6 @@ def rsync(
     cmd = cmd.format(options, source, user, host, target)
     result = c.local(cmd, hide=hide_output)
     if result:
-        logger.info(f"Succesfully ran `{result.command}`")
+        logger.info(f"Successfully ran `{result.command}`")
     else:
         raise RuntimeError("rsync failed")

--- a/src/nemo_run/core/tunnel/rsync.py
+++ b/src/nemo_run/core/tunnel/rsync.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Iterable
+
+from fabric import Connection
+
+logger = logging.getLogger(__name__)
+
+
+# This is adapted from https://github.com/fabric/patchwork/blob/master/patchwork/transfers.py
+# Cannot use the original library because of ImportError: cannot import name 'six' from 'invoke.vendor'
+def rsync(
+    c: Connection,
+    source: str,
+    target: str,
+    exclude: str | Iterable[str] = (),
+    delete: bool = False,
+    strict_host_keys: bool = True,
+    rsync_opts: str = "",
+    ssh_opts: str = "",
+    hide_output: bool = True,
+):
+    logger.info(f"rsyncing {source} to {target} ...")
+    # Turn single-string exclude into a one-item list for consistency
+    if isinstance(exclude, str):
+        exclude = [exclude]
+    # Create --exclude options from exclude list
+    exclude_opts = ' --exclude "{}"' * len(exclude)
+    # Double-backslash-escape
+    exclusions = tuple([str(s).replace('"', '\\\\"') for s in exclude])
+    # Honor SSH key(s)
+    key_string = ""
+    # TODO: seems plausible we need to look in multiple places if there's too
+    # much deferred evaluation going on in how we eg source SSH config files
+    # and so forth, re: connect_kwargs
+    # TODO: we could get VERY fancy here by eg generating a tempfile from any
+    # in-memory-only keys...but that's also arguably a security risk, so...
+    keys = c.connect_kwargs.get("key_filename", [])
+    # TODO: would definitely be nice for Connection/FabricConfig to expose an
+    # always-a-list, always-up-to-date-from-all-sources attribute to save us
+    # from having to do this sort of thing. (may want to wait for Paramiko auth
+    # overhaul tho!)
+    if isinstance(keys, str):
+        keys = [keys]
+    if keys:
+        key_string = "-i " + " -i ".join(keys)
+    # Get base cxn params
+    user, host, port = c.user, c.host, c.port
+    port_string = "-p {}".format(port)
+    # Remote shell (SSH) options
+    rsh_string = ""
+    # Strict host key checking
+    disable_keys = "-o StrictHostKeyChecking=no"
+    if not strict_host_keys and disable_keys not in ssh_opts:
+        ssh_opts += " {}".format(disable_keys)
+    rsh_parts = [key_string, port_string, ssh_opts]
+    if any(rsh_parts):
+        rsh_string = "--rsh='ssh {}'".format(" ".join(rsh_parts))
+    # Set up options part of string
+    options_map = {
+        "delete": "--delete" if delete else "",
+        "exclude": exclude_opts.format(*exclusions),
+        "rsh": rsh_string,
+        "extra": rsync_opts,
+    }
+    options = "{delete}{exclude} -pthrvz {extra} {rsh}".format(**options_map)
+    # Create and run final command string
+    # TODO: richer host object exposing stuff like .address_is_ipv6 or whatever
+    if host.count(":") > 1:
+        # Square brackets are mandatory for IPv6 rsync address,
+        # even if port number is not specified
+        cmd = "rsync {} {} [{}@{}]:{}"
+    else:
+        cmd = "rsync {} {} {}@{}:{}"
+    cmd = cmd.format(options, source, user, host, target)
+    result = c.local(cmd, hide=hide_output)
+    if result:
+        logger.info(f"Succesfully ran `{result.command}`")
+    else:
+        raise RuntimeError("rsync failed")

--- a/src/nemo_run/run/torchx_backend/launcher.py
+++ b/src/nemo_run/run/torchx_backend/launcher.py
@@ -39,11 +39,12 @@ def launch(
     executable: AppDef,
     executor_name: str,
     executor: Executor,
-    dryrun: Literal[True] = ...,
+    dryrun: Literal[True],
     wait: bool = False,
     log: bool = False,
     parent_run_id: Optional[str] = None,
     runner: Runner | None = None,
+    log_dryrun: bool = ...,
 ) -> tuple[None, None]: ...
 
 
@@ -52,11 +53,12 @@ def launch(
     executable: AppDef,
     executor_name: str,
     executor: Executor,
-    dryrun: Literal[False] = ...,
+    dryrun: Literal[False],
     wait: bool = False,
     log: bool = False,
     parent_run_id: Optional[str] = None,
     runner: Runner | None = None,
+    log_dryrun: bool = ...,
 ) -> tuple[str, specs.AppStatus]: ...
 
 
@@ -70,6 +72,7 @@ def launch(
     log: bool = False,
     parent_run_id: Optional[str] = None,
     runner: Runner | None = None,
+    log_dryrun: bool = False,
 ) -> tuple[str | None, specs.AppStatus | None]: ...
 
 
@@ -82,6 +85,7 @@ def launch(
     log: bool = False,
     parent_run_id: Optional[str] = None,
     runner: Runner | None = None,
+    log_dryrun: bool = False,
 ) -> tuple[str | None, specs.AppStatus | None]:
     runner = runner or get_runner()
 
@@ -92,8 +96,10 @@ def launch(
             cfg=executor,
             parent_run_id=parent_run_id,
         )
-        CONSOLE.log("\n=== APPLICATION ===\n")
-        CONSOLE.log(dryrun_info)
+        if log_dryrun:
+            CONSOLE.log("\n=== APPLICATION ===\n")
+            CONSOLE.log(dryrun_info)
+
         return None, None
     else:
         app_handle = runner.run(


### PR DESCRIPTION
This also changes the order of shipping files via the tunnel. Previously, each task would ship its files sequentially. Moreover, since tasks were also launched sequentially, this essentially meant calling `sftp.put` on each file, which was extremely slow. It uses a modified version of https://github.com/fabric/patchwork/blob/master/patchwork/transfers.py to construct the rsync call.

This PR first prepares the entire experiment directory, then rsyncs it to the tunnel, then launches the job. 

With this PR: `rsync` will be a required tool, but most systems have it built in so should be fine for now.

Results:

Simple experiment with 5 job groups
```python
    inline_script = run.Script(
        inline="""
echo "Hello 1"
echo "Hello 2"
"""
    )

    with run.Experiment("slurm-demo", executor=executor, log_level="INFO") as exp:
        for i in range(5):
            exp.add([inline_script, inline_script], tail_logs=True, name=f"my-test-run-{i}")
        exp.run(detach=True, tail_logs=True, sequential=False)
```

Before this PR:
```
Benchmark 1: python test_slurm.py
  Time (mean ± σ):     62.132 s ±  0.912 s    [User: 4.972 s, System: 0.463 s]
  Range (min … max):   61.487 s … 62.776 s    2 runs
```

After this PR:
```
Benchmark 1: python test_slurm.py
  Time (mean ± σ):     22.131 s ±  1.450 s    [User: 5.655 s, System: 0.553 s]
  Range (min … max):   21.105 s … 23.156 s    2 runs
```

This will scale even better with more jobs as rsync is highly optimized.