### PR TITLE
Fix slurm environment variables for non-het task groups

### DIFF
--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -833,15 +833,14 @@ class SlurmBatchRequest:
             return _container_flags
 
         for group_ind, command_group in enumerate(self.command_groups):
+            resource_req = self.slurm_config.resource_group[group_ind]
+            current_env_vars = []
+            for key, value in resource_req.env_vars.items():
+                current_env_vars.append(f"export {key.upper()}={value}")
+
+            group_env_vars.append(current_env_vars)
+
             if self.slurm_config.heterogeneous:
-                resource_req = self.slurm_config.resource_group[group_ind]
-
-                current_env_vars = []
-                for key, value in resource_req.env_vars.items():
-                    current_env_vars.append(f"export {key.upper()}={value}")
-
-                group_env_vars.append(current_env_vars)
-
                 het_group = f"--het-group={group_ind}"
                 het_stdout = srun_stdout.replace(original_job_name, self.jobs[group_ind])
                 het_stderr = stderr_flags.copy()
@@ -886,7 +885,6 @@ class SlurmBatchRequest:
                 if self.slurm_config.run_as_group and len(self.slurm_config.resource_group) == len(
                     self.command_groups
                 ):
-                    resource_req = self.slurm_config.resource_group[group_ind]
                     _container_flags = get_container_flags(
                         base_mounts=resource_req.container_mounts,
                         src_job_dir=os.path.join(

--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -833,14 +833,15 @@ class SlurmBatchRequest:
             return _container_flags
 
         for group_ind, command_group in enumerate(self.command_groups):
-            resource_req = self.slurm_config.resource_group[group_ind]
-            current_env_vars = []
-            for key, value in resource_req.env_vars.items():
-                current_env_vars.append(f"export {key.upper()}={value}")
-
-            group_env_vars.append(current_env_vars)
-
             if self.slurm_config.heterogeneous:
+                resource_req = self.slurm_config.resource_group[group_ind]
+
+                current_env_vars = []
+                for key, value in resource_req.env_vars.items():
+                    current_env_vars.append(f"export {key.upper()}={value}")
+
+                group_env_vars.append(current_env_vars)
+
                 het_group = f"--het-group={group_ind}"
                 het_stdout = srun_stdout.replace(original_job_name, self.jobs[group_ind])
                 het_stderr = stderr_flags.copy()
@@ -885,6 +886,13 @@ class SlurmBatchRequest:
                 if self.slurm_config.run_as_group and len(self.slurm_config.resource_group) == len(
                     self.command_groups
                 ):
+                    resource_req = self.slurm_config.resource_group[group_ind]
+                    current_env_vars = []
+                    for key, value in resource_req.env_vars.items():
+                        current_env_vars.append(f"export {key.upper()}={value}")
+
+                    group_env_vars.append(current_env_vars)
+
                     _container_flags = get_container_flags(
                         base_mounts=resource_req.container_mounts,
                         src_job_dir=os.path.join(

--- a/test/core/execution/artifacts/group_resource_req_slurm.sh
+++ b/test/core/execution/artifacts/group_resource_req_slurm.sh
@@ -35,12 +35,18 @@ head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
 
 # Command 1
 
+export CUSTOM_ENV_1=some_value_1
+
+
 srun --output /some/job/dir/sample_job/log-your_account-account.sample_job-0_%j_${SLURM_RESTART_COUNT:-0}.out --container-image some-image --container-mounts /some/job/dir/sample_job:/nemo_run --container-workdir /nemo_run/code --wait=60 --kill-on-bad-exit=1 bash ./scripts/start_server.sh & pids[0]=$!
 
 sleep 10
 
 
 # Command 2
+
+export CUSTOM_ENV_1=some_value_1
+
 
 srun --output /some/job/dir/sample_job/log-your_account-account.sample_job-1_%j_${SLURM_RESTART_COUNT:-0}.out --container-image different_container_image --container-mounts /some/job/dir/sample_job:/nemo_run --container-workdir /nemo_run/code --wait=60 --kill-on-bad-exit=1 --mpi=pmix bash ./scripts/echo.sh server_host=$het_group_host_0 & pids[1]=$!
 

--- a/test/core/execution/test_slurm.py
+++ b/test/core/execution/test_slurm.py
@@ -223,6 +223,7 @@ class TestSlurmBatchRequest:
                 user="your-user",
             ),
             wait_time_for_group_job=10,
+            env_vars={"CUSTOM_ENV_1": "some_value_1"},
         )
         executor_2 = executor_1.clone()
         executor_2.container_image = "different_container_image"


### PR DESCRIPTION
There was a bug that when task group was used and heterogeneous is False, the environment variables were ignored in slurm