### PR TITLE
Add validation for run.Partial based tasks in Experiment

### DIFF
--- a/src/nemo_run/run/api.py
+++ b/src/nemo_run/run/api.py
@@ -75,7 +75,7 @@ def run(
     )
     name = name or default_name
     with Experiment(title=name, executor=executor, log_level=log_level) as exp:
-        exp.add(fn_or_script, tail_logs=tail_logs, plugins=plugins)
+        exp.add(fn_or_script, tail_logs=tail_logs, plugins=plugins, name=name)
         if dryrun:
             exp.dryrun()
             return

--- a/src/nemo_run/run/experiment.py
+++ b/src/nemo_run/run/experiment.py
@@ -19,6 +19,7 @@ import importlib.util
 import inspect
 import json
 import os
+import pprint
 import shutil
 import sys
 import time
@@ -29,6 +30,7 @@ from typing import Optional, Type, Union
 
 import fiddle as fdl
 import networkx as nx
+from fiddle._src import daglish, diffing
 from rich.console import Group
 from rich.live import Live
 from rich.panel import Panel
@@ -378,6 +380,8 @@ nemo experiment cancel {exp_id} 0
         else:
             task_id = name
 
+        self._validate_task(task_info=task_id, task=task)
+
         executor = executor.clone()
         executor.assign(
             self._id,
@@ -418,6 +422,9 @@ nemo experiment cancel {exp_id} 0
         else:
             task_id = name
 
+        for i, _task in enumerate(tasks):
+            self._validate_task(task_info=f"Job Group: {task_id}, job index: {i}", task=_task)
+
         executors = executor if isinstance(executor, list) else [executor]
         cloned_executors = []
         for executor in executors:
@@ -448,6 +455,30 @@ nemo experiment cancel {exp_id} 0
         job_group.prepare()
         self._jobs.append(job_group)
         return job_group.id
+
+    def _validate_task(self, task_info: str, task: Union[Partial, Script]) -> None:
+        valid = True
+        message = ""
+        if isinstance(task, Partial):
+            serializer = ZlibJSONSerializer()
+            serialized = serializer.serialize(task)
+            deserialized = serializer.deserialize(serialized)
+            diff = diffing.build_diff(deserialized, task)
+            diff = {
+                daglish.path_str(d.target): (d.new_value if hasattr(d, "new_value") else None)  # type: ignore
+                for d in diff.changes
+            }
+            if deserialized != task:
+                valid = False
+                message += f"""
+Deserialized task does not match original task. The following paths in your task need to be wrapped in `run.Config` or `run.Partial`:
+
+{pprint.PrettyPrinter(indent=4).pformat(diff)}
+
+For more information about `run.Config` and `run.Partial`, please refer to https://github.com/NVIDIA/NeMo-Run/blob/main/docs/source/guides/configuration.md.
+"""
+        if not valid:
+            raise RuntimeError(f"Failed to validate task {task_info}.\n{message}")
 
     def add(
         self,

--- a/src/nemo_run/run/experiment.py
+++ b/src/nemo_run/run/experiment.py
@@ -265,6 +265,7 @@ nemo experiment cancel {exp_id} 0
         log_level: str = "INFO",
         _reconstruct: bool = False,
         jobs: list[Job | JobGroup] | None = None,
+        base_dir: str | None = None,
     ) -> None:
         """
         Initializes an experiment run by creating its metadata directory and saving the experiment config.
@@ -288,7 +289,8 @@ nemo experiment cancel {exp_id} 0
         self._title = title
         self._id = id or f"{title}_{int(time.time())}"
 
-        self._exp_dir = os.path.join(NEMORUN_HOME, "experiments", title, self._id)
+        base_dir = base_dir or NEMORUN_HOME
+        self._exp_dir = os.path.join(base_dir, "experiments", title, self._id)
 
         self.log_level = log_level
         self._runner = get_runner()

--- a/test/dummy_factory.py
+++ b/test/dummy_factory.py
@@ -25,6 +25,14 @@ class DummyModel:
     activation: str = "relu"
 
 
+class DummyTrainer:
+    def __init__(self, num_epochs: int = 10):
+        self.num_epochs = num_epochs
+
+    def __hash__(self) -> int:
+        return hash((self.num_epochs))
+
+
 @dataclass
 class NestedModel:
     dummy: DummyModel
@@ -86,6 +94,9 @@ def plugin_list(arg: int = 20) -> List[run.Plugin]:
         dummy_plugin(arg),
         AnotherPlugin(another_arg=arg),
     ]
+
+
+def dummy_train(dummy_model: DummyModel, dummy_trainer: DummyTrainer): ...
 
 
 if __name__ == "__main__":

--- a/test/dummy_factory.py
+++ b/test/dummy_factory.py
@@ -32,6 +32,9 @@ class DummyTrainer:
     def __hash__(self) -> int:
         return hash((self.num_epochs))
 
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, DummyTrainer) and self.num_epochs == value.num_epochs
+
 
 @dataclass
 class NestedModel:

--- a/test/run/test_experiment.py
+++ b/test/run/test_experiment.py
@@ -1,0 +1,26 @@
+import pytest
+from fiddle._src.experimental.serialization import UnserializableValueError
+
+import nemo_run as run
+from test.dummy_factory import DummyModel, DummyTrainer, dummy_train
+
+
+@pytest.fixture
+def experiment(tmpdir):
+    return run.Experiment("dummy_experiment", base_dir=tmpdir)
+
+
+class TestValidateTask:
+    def test_validate_task(self, experiment: run.Experiment):
+        experiment._validate_task("valid_script", run.Script(inline="echo 'hello world'"))
+
+        valid_partial = run.Partial(
+            dummy_train, dummy_model=run.Config(DummyModel), dummy_trainer=run.Config(DummyTrainer)
+        )
+        experiment._validate_task("valid_partial", valid_partial)
+
+        invalid_partial = run.Partial(
+            dummy_train, dummy_model=DummyModel(), dummy_trainer=DummyTrainer()
+        )
+        with pytest.raises(UnserializableValueError):
+            experiment._validate_task("invalid_partial", invalid_partial)


### PR DESCRIPTION
In case of error, output looks like
```
RuntimeError: Failed to validate task l2_llama_test.

Deserialized task does not match original task. The following paths in your task need to be wrapped in `run.Config` or `run.Partial`:

{   '.data.tokenizer': <nemo.collections.common.tokenizers.sentencepiece_tokenizer.SentencePieceTokenizer object at 0x72b8369bc3a0>,
    '.model': LlamaModel()}

For more information about `run.Config` and `run.Partial`, please refer to https://github.com/NVIDIA/NeMo-Run/blob/main/docs/source/guides/configuration.md.
```