### PR TITLE
Add a helper function get_executor for retrieving executors from NEMORUN_HOME

### DIFF
--- a/src/nemo_run/__init__.py
+++ b/src/nemo_run/__init__.py
@@ -16,7 +16,13 @@
 from nemo_run import cli
 from nemo_run.api import autoconvert, dryrun_fn
 from nemo_run.config import Config, ConfigurableMixin, Partial, Script
-from nemo_run.core.execution.base import Executor, ExecutorMacros, FaultTolerance, Torchrun
+from nemo_run.core.execution.base import (
+    Executor,
+    ExecutorMacros,
+    FaultTolerance,
+    Torchrun,
+    get_executor,
+)
 from nemo_run.core.execution.docker import DockerExecutor
 from nemo_run.core.execution.local import LocalExecutor
 from nemo_run.core.execution.skypilot import SkypilotExecutor
@@ -40,6 +46,7 @@ __all__ = [
     "DockerExecutor",
     "dryrun_fn",
     "Executor",
+    "get_executor",
     "ExecutorMacros",
     "Experiment",
     "FaultTolerance",

--- a/src/nemo_run/__init__.py
+++ b/src/nemo_run/__init__.py
@@ -21,7 +21,7 @@ from nemo_run.core.execution.base import (
     ExecutorMacros,
     FaultTolerance,
     Torchrun,
-    get_executor,
+    import_executor,
 )
 from nemo_run.core.execution.docker import DockerExecutor
 from nemo_run.core.execution.local import LocalExecutor
@@ -46,7 +46,7 @@ __all__ = [
     "DockerExecutor",
     "dryrun_fn",
     "Executor",
-    "get_executor",
+    "import_executor",
     "ExecutorMacros",
     "Experiment",
     "FaultTolerance",

--- a/src/nemo_run/core/execution/base.py
+++ b/src/nemo_run/core/execution/base.py
@@ -229,7 +229,7 @@ class Executor(ConfigurableMixin):
     def cleanup(self, handle: str): ...
 
 
-def get_executor(
+def import_executor(
     name: str, file_path: Optional[str] = None, call: bool = True, **kwargs
 ) -> Executor:
     """
@@ -243,8 +243,8 @@ def get_executor(
     It is similar to ~/.ssh/config and allows you to use executors across your projects without having to redefine them.
 
     Example:
-        executor = get_executor("local", file_path="path/to/executors.py")
-        executor = get_executor("gpu")  # Uses the default location of os.path.join(NEMORUN_HOME, "executors.py")
+        executor = import_executor("local", file_path="path/to/executors.py")
+        executor = import_executor("gpu")  # Uses the default location of os.path.join(NEMORUN_HOME, "executors.py")
 
     Args:
         name (str): The name of the executor to retrieve.

--- a/src/nemo_run/core/execution/base.py
+++ b/src/nemo_run/core/execution/base.py
@@ -270,6 +270,7 @@ def get_executor(name: str, file_path: Optional[str] = None) -> Executor:
     module = importlib.util.module_from_spec(spec)
     assert spec.loader
     spec.loader.exec_module(module)
-    executor_map = getattr(module, "EXECUTOR_MAP")
-    assert name in executor_map, f"Executor {name} not found."
-    return executor_map[name]
+    executor_fn = getattr(module, name)
+    if not callable(executor_fn):
+        return executor_fn
+    return executor_fn()  # type: ignore


### PR DESCRIPTION
Similar to workspace.py, but specifically for executors. 

Example `executors.py`
```python
import nemo_run as run

EXECUTOR_MAP = {
    "local": run.LocalExecutor()
}
```

Usage:
```python
run.get_executor("local")
```