### PR TITLE
Return correct exit code in slurm job groups

### DIFF
--- a/src/nemo_run/core/execution/templates/slurm.sh.j2
+++ b/src/nemo_run/core/execution/templates/slurm.sh.j2
@@ -82,6 +82,7 @@ while ! $all_done; do
                     kill -9 "$other_pid"
                 fi
             done
+            break 2
         fi
     done
 

--- a/test/core/execution/artifacts/ft_het_slurm.sh
+++ b/test/core/execution/artifacts/ft_het_slurm.sh
@@ -115,6 +115,7 @@ while ! $all_done; do
                     kill -9 "$other_pid"
                 fi
             done
+            break 2
         fi
     done
 

--- a/test/core/execution/artifacts/group_resource_req_slurm.sh
+++ b/test/core/execution/artifacts/group_resource_req_slurm.sh
@@ -74,6 +74,7 @@ while ! $all_done; do
                     kill -9 "$other_pid"
                 fi
             done
+            break 2
         fi
     done
 

--- a/test/core/execution/artifacts/group_slurm.sh
+++ b/test/core/execution/artifacts/group_slurm.sh
@@ -68,6 +68,7 @@ while ! $all_done; do
                     kill -9 "$other_pid"
                 fi
             done
+            break 2
         fi
     done
 

--- a/test/core/execution/artifacts/het_slurm.sh
+++ b/test/core/execution/artifacts/het_slurm.sh
@@ -90,6 +90,7 @@ while ! $all_done; do
                     kill -9 "$other_pid"
                 fi
             done
+            break 2
         fi
     done
 


### PR DESCRIPTION
Fixes a bug in how completion is handled in slurm job groups. 

> Previously, When a process completes, all the remaining processes are killed (correctly) with 'kill -9', this will make them exit with non-zero exit code (9) and 'exitcode' variable will lose the successful completion signal (exit code 0 from first task that completed). Later batch script will exit with exit code 9.

Now, we break out of the for loop so that the first exit code is preserved.