### PR TITLE
Support Annotated in CLI

### DIFF
--- a/src/nemo_run/cli/cli_parser.py
+++ b/src/nemo_run/cli/cli_parser.py
@@ -702,6 +702,14 @@ class TypeParser:
             elif buildable_type == "Partial":
                 return Partial(config_type)
 
+        if str(annotation).startswith("typing.Annotated"):
+            args = get_args(annotation)
+            if str(args[0]).startswith("typing.Optional") and len(args) > 1:
+                cfg_type = get_args(args[0])[0]
+                buildable = args[1].__origin__
+                if issubclass(buildable, fdl.Buildable):
+                    return buildable(cfg_type)
+
         return Config(annotation)
 
     def parse_int(self, value: str, _: Type) -> int:

--- a/test/cli/test_api.py
+++ b/test/cli/test_api.py
@@ -15,7 +15,7 @@
 
 from configparser import ConfigParser
 from dataclasses import dataclass
-from typing import Annotated, List, Optional, Union
+from typing import Annotated, List, Optional, Tuple, Union
 from unittest.mock import Mock, patch
 
 import fiddle as fdl
@@ -441,7 +441,7 @@ class Optimizer:
 
     learning_rate: float = 0.001
     weight_decay: float = 1e-5
-    betas: List[float] = [0.9, 0.999]
+    betas: Tuple[float, float] = (0.9, 0.999)
 
 
 @run.cli.factory
@@ -621,11 +621,11 @@ class TestEntrypointRunner:
         assert "Training model with the following configuration:" in output
         assert "Model: Model(hidden_size=1024, num_layers=3, activation='relu')" in output
         assert (
-            "Optimizer: Optimizer(learning_rate=0.001, weight_decay=1e-05, betas=[0.9, 0.999])"
+            "Optimizer: Optimizer(learning_rate=0.001, weight_decay=1e-05, betas=(0.9, 0.999))"
             in output
         )
         assert "Epochs: 30" in output
-        assert "Batch size: 1024" in output
+        assert "Batch size: 32" in output
         assert "Training completed!" in output
 
         # Check that all epochs were simulated

--- a/test/cli/test_api.py
+++ b/test/cli/test_api.py
@@ -15,7 +15,7 @@
 
 from configparser import ConfigParser
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Annotated, List, Optional, Union
 from unittest.mock import Mock, patch
 
 import fiddle as fdl
@@ -439,9 +439,9 @@ class Model:
 class Optimizer:
     """Dummy optimizer config"""
 
-    learning_rate: float
-    weight_decay: float
-    betas: List[float]
+    learning_rate: float = 0.001
+    weight_decay: float = 1e-5
+    betas: List[float] = [0.9, 0.999]
 
 
 @run.cli.factory
@@ -504,6 +504,22 @@ def train_model(
     print("Training completed!")
 
     return {"model": model, "optimizer": optimizer, "epochs": epochs, "batch_size": batch_size}
+
+
+@run.cli.entrypoint(
+    namespace="my_llm",
+    skip_confirmation=True,
+)
+def train_model_default_optimizer(
+    model: Model,
+    optimizer: Annotated[Optional[Optimizer], run.Config[Optimizer]] = None,
+    epochs: int = 10,
+    batch_size: int = 32,
+):
+    if optimizer is None:
+        optimizer = Optimizer()
+
+    return train_model(model, optimizer, epochs, batch_size)
 
 
 @run.cli.factory(target=train_model)
@@ -575,6 +591,37 @@ class TestEntrypointRunner:
         assert "Model: Model(hidden_size=1024, num_layers=3, activation='relu')" in output
         assert (
             "Optimizer: Optimizer(learning_rate=0.005, weight_decay=1e-05, betas=[0.9, 0.999])"
+            in output
+        )
+        assert "Epochs: 30" in output
+        assert "Batch size: 1024" in output
+        assert "Training completed!" in output
+
+        # Check that all epochs were simulated
+        for i in range(1, 31):
+            assert f"Epoch {i}/30" in output
+
+    def test_with_defaults_no_optimizer(self, runner, app):
+        # Test CLI execution with default factory
+        result = runner.invoke(
+            app,
+            [
+                "my_llm",
+                "train_model_default_optimizer",
+                "model=my_model(hidden_size=1024)",
+                "epochs=30",
+                "run.skip_confirmation=True",
+            ],
+            env={"INCLUDE_WORKSPACE_FILE": "false"},
+        )
+        assert result.exit_code == 0
+
+        # Parse the output to check the values
+        output = result.stdout
+        assert "Training model with the following configuration:" in output
+        assert "Model: Model(hidden_size=1024, num_layers=3, activation='relu')" in output
+        assert (
+            "Optimizer: Optimizer(learning_rate=0.001, weight_decay=1e-05, betas=[0.9, 0.999])"
             in output
         )
         assert "Epochs: 30" in output


### PR DESCRIPTION
The script I attached below can be run with:

![CleanShot 2024-11-27 at 16 31 38@2x](https://github.com/user-attachments/assets/5986608b-9815-4514-803c-f35b112b03bb)

Script:

```python
from dataclasses import dataclass
from pathlib import Path
from typing import Annotated, Optional, Union

import nemo_run as run


@dataclass
class QuantizationConfig:
    """Quantization parameters.

    Available quantization methods are listed in `QUANT_CFG_CHOICES` dictionary above.
    Please consult Model Optimizer documentation https://nvidia.github.io/TensorRT-Model-Optimizer/ for details.

    Quantization algorithm can also be conveniently set to None to perform only weights export step
    for TensorRT-LLM deployment. This is useful to getting baseline results for a full-precision model.
    """

    algorithm: Optional[str] = "fp8"
    awq_block_size: int = 128
    sq_alpha: float = 0.5
    enable_kv_cache: Optional[bool] = None

    calibration_dataset: str = "cnn_dailymail"
    calibration_dataset_size: int = 512
    calibration_batch_size: int = 64
    calibration_seq_len: int = 128


@dataclass
class ExportConfig:
    """Inference configuration for the quantized TensorRT-LLM checkpoint."""

    path: Union[Path, str]
    dtype: Union[str, int] = "bf16"
    decoder_type: Optional[str] = None
    inference_tensor_parallel: int = 1
    inference_pipeline_parallel: int = 1
    generate_sample: bool = False

    def __post_init__(self):
        self.path = Path(self.path)


def ptq(
    nemo_checkpoint: str,
    export_config: ExportConfig,
    calib_tp: int = 1,
    calib_pp: int = 1,
    quantization_config: Annotated[
        Optional[QuantizationConfig], run.Config[QuantizationConfig]
    ] = None,
):
    if not quantization_config:
        quantization_config = QuantizationConfig()

    print(f"Nemo checkpoint: {nemo_checkpoint}")
    print(f"Export config: {export_config}")
    print(f"Calib TP: {calib_tp}")
    print(f"Calib PP: {calib_pp}")
    print(f"Quantization config: {quantization_config}")


if __name__ == "__main__":
    run.cli.main(ptq)
```