### PR TITLE
correct nsys path

### DIFF
--- a/src/nemo_run/core/execution/docker.py
+++ b/src/nemo_run/core/execution/docker.py
@@ -208,9 +208,7 @@ class DockerExecutor(Executor):
         ctx.run(f"mkdir -p {local_code_extraction_path}")
 
         if self.get_launcher().nsys_profile:
-            remote_nsys_extraction_path = os.path.join(
-                self.job_dir, job_name, self.get_launcher().nsys_folder
-            )
+            remote_nsys_extraction_path = os.path.join(self.job_dir, self.get_launcher().nsys_folder)
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
         if local_pkg:
             ctx.run(

--- a/src/nemo_run/core/execution/docker.py
+++ b/src/nemo_run/core/execution/docker.py
@@ -208,7 +208,9 @@ class DockerExecutor(Executor):
         ctx.run(f"mkdir -p {local_code_extraction_path}")
 
         if self.get_launcher().nsys_profile:
-            remote_nsys_extraction_path = os.path.join(self.job_dir, self.get_launcher().nsys_folder)
+            remote_nsys_extraction_path = os.path.join(
+                self.job_dir, self.get_launcher().nsys_folder
+            )
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
         if local_pkg:
             ctx.run(

--- a/src/nemo_run/core/execution/skypilot.py
+++ b/src/nemo_run/core/execution/skypilot.py
@@ -301,9 +301,7 @@ class SkypilotExecutor(Executor):
         ctx.run(f"mkdir -p {local_code_extraction_path}")
 
         if self.get_launcher().nsys_profile:
-            remote_nsys_extraction_path = os.path.join(
-                self.job_dir, job_name, self.get_launcher().nsys_folder
-            )
+            remote_nsys_extraction_path = os.path.join(self.job_dir, self.get_launcher().nsys_folder)
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
         if local_pkg:
             ctx.run(

--- a/src/nemo_run/core/execution/skypilot.py
+++ b/src/nemo_run/core/execution/skypilot.py
@@ -301,7 +301,9 @@ class SkypilotExecutor(Executor):
         ctx.run(f"mkdir -p {local_code_extraction_path}")
 
         if self.get_launcher().nsys_profile:
-            remote_nsys_extraction_path = os.path.join(self.job_dir, self.get_launcher().nsys_folder)
+            remote_nsys_extraction_path = os.path.join(
+                self.job_dir, self.get_launcher().nsys_folder
+            )
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
         if local_pkg:
             ctx.run(

--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -520,7 +520,6 @@ class SlurmExecutor(Executor):
     def get_launcher_prefix(self) -> Optional[list[str]]:
         launcher = self.get_launcher()
         if launcher.nsys_profile:
-            os.makedirs(os.path.join(self.job_dir, launcher.nsys_folder), exist_ok=True)
             return launcher.get_nsys_prefix(profile_dir=f"/{RUNDIR_NAME}")
 
     def package_configs(self, *cfgs: tuple[str, str]) -> list[str]:
@@ -595,7 +594,9 @@ class SlurmExecutor(Executor):
         ctx.run(f"mkdir -p {local_code_extraction_path}")
 
         if self.get_launcher().nsys_profile:
-            remote_nsys_extraction_path = os.path.join(self.job_dir, self.get_launcher().nsys_folder)
+            remote_nsys_extraction_path = os.path.join(
+                self.job_dir, self.get_launcher().nsys_folder
+            )
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
             # Touch hidden init file
             ctx.run(f"touch {remote_nsys_extraction_path}/.init")

--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -520,6 +520,7 @@ class SlurmExecutor(Executor):
     def get_launcher_prefix(self) -> Optional[list[str]]:
         launcher = self.get_launcher()
         if launcher.nsys_profile:
+            os.makedirs(os.path.join(self.job_dir, launcher.nsys_folder), exist_ok=True)
             return launcher.get_nsys_prefix(profile_dir=f"/{RUNDIR_NAME}")
 
     def package_configs(self, *cfgs: tuple[str, str]) -> list[str]:
@@ -594,9 +595,7 @@ class SlurmExecutor(Executor):
         ctx.run(f"mkdir -p {local_code_extraction_path}")
 
         if self.get_launcher().nsys_profile:
-            remote_nsys_extraction_path = os.path.join(
-                self.job_dir, job_name, self.get_launcher().nsys_folder
-            )
+            remote_nsys_extraction_path = os.path.join(self.job_dir, self.get_launcher().nsys_folder)
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
             # Touch hidden init file
             ctx.run(f"touch {remote_nsys_extraction_path}/.init")


### PR DESCRIPTION
The nsys profile path before this PR was- `<exp_name>/<exp_id>/<exp_name>/<exp_name>/nsys_profile/`. After this PR, nsys profile path created is `<exp_name>/<exp_id>/<exp_name>/nsys_profile/`.