### PR TITLE
Fix for multigpu runs with docker executor

### DIFF
--- a/src/nemo_run/run/torchx_backend/schedulers/docker.py
+++ b/src/nemo_run/run/torchx_backend/schedulers/docker.py
@@ -88,7 +88,7 @@ class PersistentDockerScheduler(SchedulerMixin, DockerScheduler):  # type: ignor
             cmd = [role.entrypoint] + role.args
             containers.append(
                 DockerContainer(
-                    name=f"{executor.experiment_id}_{role.name}",
+                    name=f"{executor.experiment_id}_{role.name}".replace('_', '-'),
                     command=cmd,
                     executor=_current_executor,
                     extra_env=role.env,


### PR DESCRIPTION
Without this change I get

```
nemo-run-0/0 --------------------------------------------------------------------------                                                                                                                           
nemo-run-0/0 While trying to create a regular expression of the node names                                                                                                                                        
nemo-run-0/0 used in this application, the regex parser has detected the                                                                                                                                          
nemo-run-0/0 presence of an illegal character in the following node name:                                                                                                                                         
nemo-run-0/0
nemo-run-0/0   node:  eval_1736300653_nemo-run-0
nemo-run-0/0
nemo-run-0/0 Node names must be composed of a combination of ascii letters,
nemo-run-0/0 digits, dots, and the hyphen ('-') character. See the following
nemo-run-0/0 for an explanation:
nemo-run-0/0
nemo-run-0/0   https://en.wikipedia.org/wiki/Hostname
nemo-run-0/0
nemo-run-0/0 Please correct the error and try again.
nemo-run-0/0 --------------------------------------------------------------------------
nemo-run-0/0 --------------------------------------------------------------------------
nemo-run-0/0 An internal error has occurred in ORTE:
nemo-run-0/0
nemo-run-0/0 [[41165,0],0] FORCE-TERMINATE AT (null):1 - error ../../../../../orte/mca/plm/base/plm_base_launch_support.c(555)
nemo-run-0/0
nemo-run-0/0 This is something that should be reported to the developers.
nemo-run-0/0 --------------------------------------------------------------------------
```