### PR TITLE
Support positional args in `LazyEntrypoint._add_overwrite`

### DIFF
--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -208,6 +208,19 @@ class TestLazyEntrypoint:
         resolved = task.resolve()
         assert resolved.a == 5
 
+    def test_overwrites_as_positional_args(self):
+        def func(a: int, b: str = "dummy"):
+            pass
+
+        task = LazyEntrypoint(func)
+        task._add_overwrite("5", "my_dummy")
+        assert ("a", "=", "5") in task._args_
+        assert ("b", "=", "my_dummy") in task._args_
+
+        resolved = task.resolve()
+        assert resolved.a == 5
+        assert resolved.b == "my_dummy"
+
 
 class TestLazyEntrypointFromCmd:
     def test_from_cmd_with_script(self):


### PR DESCRIPTION
Hi team,

I found that `nemo_run.cli.entrypoint` doesn't support positional args when using CLI, but the docstrings from NeMo imply that it should:

https://github.com/NVIDIA/NeMo/blob/d82f53a23d013cfe6928a514f530b74fc3ab2636/nemo/collections/llm/api.py#L511-L521

```bash
# Failed -> ValueError: Invalid overwrite format: llama32_1b
nemo llm import llama3_8b source="hf://meta-llama/Llama-3.1-8B"

# Succeeded
nemo llm import model=llama3_8b source="hf://meta-llama/Llama-3.1-8B"
```

This PR adds support for positional args by trying to retrieve the argument names first in `LazyEntrypoint._add_overwrite`.
A corresponding test has been added to verify these changes.