### PR TITLE
Add nsys command argument to profile cuda graph workload

### DIFF
--- a/src/nemo_run/core/execution/base.py
+++ b/src/nemo_run/core/execution/base.py
@@ -50,6 +50,7 @@ class Launcher(ConfigurableMixin):
                 "true",
                 "--capture-range=cudaProfilerApi",
                 "--capture-range-end=stop",
+                "--cuda-graph-trace=node",
             ]
             return args
 

--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -595,7 +595,7 @@ class SlurmExecutor(Executor):
 
         if self.get_launcher().nsys_profile:
             remote_nsys_extraction_path = os.path.join(
-                self.job_dir, self.get_launcher().nsys_folder
+                self.job_dir, job_name, self.get_launcher().nsys_folder
             )
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
             # Touch hidden init file

--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -595,7 +595,7 @@ class SlurmExecutor(Executor):
 
         if self.get_launcher().nsys_profile:
             remote_nsys_extraction_path = os.path.join(
-                self.job_dir, job_name, self.get_launcher().nsys_folder
+                self.job_dir, self.get_launcher().nsys_folder
             )
             ctx.run(f"mkdir -p {remote_nsys_extraction_path}")
             # Touch hidden init file

--- a/test/core/execution/test_slurm.py
+++ b/test/core/execution/test_slurm.py
@@ -508,6 +508,7 @@ class TestSlurmBatchRequest:
             "true",
             "--capture-range=cudaProfilerApi",
             "--capture-range-end=stop",
+            "--cuda-graph-trace=node",
         ]
 
     def test_dummy_batch_request_warn(


### PR DESCRIPTION
This PR does two changes
1. Add nsys command argument `--cuda-graph-trace=node` to allow nsys to see into cuda graph replays
2. Fix nsys profile export path, to make it visible in the container to facilitate export