### PR TITLE
Add extract_at_root option and MacOS support for HybridPackager

### DIFF
--- a/src/nemo_run/core/packaging/git.py
+++ b/src/nemo_run/core/packaging/git.py
@@ -154,9 +154,7 @@ class GitArchivePackager(Packager):
                 f"find {relative_include_pattern} -type f | "
                 f"tar -cf {os.path.join(git_base_path, pattern_tar_file_name)} -T -"
             )
-            tar_concatenate_cmd = (
-                f"cat {pattern_tar_file_name} >> {output_file}.tmp && rm {pattern_tar_file_name}"
-            )
+            tar_concatenate_cmd = f"cat {os.path.join(git_base_path, pattern_tar_file_name)} >> {output_file}.tmp && rm {pattern_tar_file_name}"
 
             with ctx.cd(include_pattern_relative_path):
                 ctx.run(include_pattern_cmd)

--- a/src/nemo_run/core/packaging/hybrid.py
+++ b/src/nemo_run/core/packaging/hybrid.py
@@ -13,10 +13,14 @@ class HybridPackager(Packager):
     """
     A packager that combines multiple other packagers into one final archive.
     Each subpackager is mapped to a target directory name, which will become
-    the top-level folder under which that packager’s content is placed.
+    the top-level folder under which that packager's content is placed.
+
+    If `extract_at_root` is True, the contents of each sub-packager are extracted
+    directly at the root of the final archive (i.e. without being nested in a subfolder).
     """
 
     sub_packagers: Dict[str, Packager] = field(default_factory=dict)
+    extract_at_root: bool = False
 
     def package(self, path: Path, job_dir: str, name: str) -> str:
         final_tar_gz = os.path.join(job_dir, f"{name}.tar.gz")
@@ -28,7 +32,8 @@ class HybridPackager(Packager):
         ctx = Context()
         ctx.run(f"tar -cf {tmp_tar} --files-from /dev/null")
 
-        # For each subpackager, run its .package() method and extract to a subfolder
+        # For each subpackager, run its .package() method,
+        # extract the content and add it to the final tar
         for folder_name, packager in self.sub_packagers.items():
             subarchive_path = packager.package(path, job_dir, f"{name}_{folder_name}")
 
@@ -38,7 +43,22 @@ class HybridPackager(Packager):
             os.makedirs(tmp_extract_dir, exist_ok=True)
 
             ctx.run(f"tar -xf {subarchive_path} -C {tmp_extract_dir}")
-            ctx.run(f"tar -rf {tmp_tar} -C {tmp_extract_dir} . --transform='s,^,{folder_name}/,'")
+
+            # If extract_at_root is True then add files directly to the archive root.
+            # Otherwise, add them under a subfolder named after the key.
+            if self.extract_at_root:
+                ctx.run(f"tar -rf {tmp_tar} -C {tmp_extract_dir} .")
+            else:
+                sysname = os.uname().sysname
+                if sysname == "Darwin":
+                    # BSD tar uses the -s option with a chosen delimiter (here we use a comma)
+                    # The first -s replaces an entry that is exactly "."
+                    # The second -s replaces entries starting with "./" (i.e. files inside)
+                    transform_option = f"-s ',^\\.$,{folder_name},' -s ',^\\./,{folder_name}/,'"
+                else:
+                    transform_option = f"--transform='s,^,{folder_name}/,'"
+                ctx.run(f"tar {transform_option} -rf {tmp_tar} -C {tmp_extract_dir} .")
+
             ctx.run(f"rm -rf {tmp_extract_dir}")
             ctx.run(f"rm {subarchive_path}")
 


### PR DESCRIPTION
Example usage

```python
packager = run.HybridPackager(sub_packagers={"temp": packager}, extract_at_root=True)
```