### PR TITLE
Minimize io operations in experiment, avoid persisting experiment to disk before run/dryrun

### DIFF
--- a/src/nemo_run/core/execution/base.py
+++ b/src/nemo_run/core/execution/base.py
@@ -227,6 +227,9 @@ class Executor(ConfigurableMixin):
             filenames.append(filename)
         return filenames
 
+    def create_job_dir(self):
+        os.makedirs(self.job_dir, exist_ok=True)
+
     def cleanup(self, handle: str): ...
 
 

--- a/src/nemo_run/core/execution/dgxcloud.py
+++ b/src/nemo_run/core/execution/dgxcloud.py
@@ -226,7 +226,6 @@ cd /nemo_run/code
         self.experiment_dir = exp_dir
         self.job_dir = os.path.join(exp_dir, task_dir)
         self.experiment_id = exp_id
-        os.makedirs(self.job_dir, exist_ok=True)
         assert any(
             map(
                 lambda x: os.path.commonpath(

--- a/src/nemo_run/core/execution/docker.py
+++ b/src/nemo_run/core/execution/docker.py
@@ -162,7 +162,6 @@ class DockerExecutor(Executor):
         self.experiment_id = exp_id
         self.experiment_dir = exp_dir
         self.job_dir = os.path.join(exp_dir, task_dir)
-        os.makedirs(self.job_dir, exist_ok=True)
 
     def nnodes(self) -> int:
         return 1

--- a/src/nemo_run/core/execution/local.py
+++ b/src/nemo_run/core/execution/local.py
@@ -48,7 +48,6 @@ class LocalExecutor(Executor):
         self.experiment_id = exp_id
         self.experiment_dir = exp_dir
         self.job_dir = os.path.join(exp_dir, task_dir)
-        os.makedirs(self.job_dir, exist_ok=True)
 
     def nnodes(self) -> int:
         return 1

--- a/src/nemo_run/core/execution/skypilot.py
+++ b/src/nemo_run/core/execution/skypilot.py
@@ -280,8 +280,6 @@ class SkypilotExecutor(Executor):
         self.job_dir = os.path.join(exp_dir, task_dir)
         self.experiment_id = exp_id
 
-        os.makedirs(self.job_dir, exist_ok=True)
-
     def package(self, packager: Packager, job_name: str):
         assert self.experiment_id, "Executor not assigned to an experiment."
         if isinstance(packager, GitArchivePackager):

--- a/src/nemo_run/core/execution/slurm.py
+++ b/src/nemo_run/core/execution/slurm.py
@@ -514,7 +514,6 @@ class SlurmExecutor(Executor):
         self.job_dir = os.path.join(exp_dir, task_dir)
         self.experiment_id = exp_id
 
-        os.makedirs(self.job_dir, exist_ok=True)
         self.tunnel._set_job_dir(self.experiment_id)
 
     def get_launcher_prefix(self) -> Optional[list[str]]:

--- a/src/nemo_run/run/experiment.py
+++ b/src/nemo_run/run/experiment.py
@@ -578,6 +578,8 @@ For more information about `run.Config` and `run.Partial`, please refer to https
                     self.console.log(f"[bold magenta]Task Group {job.id}\n")
             job.launch(wait=False, runner=self._runner, dryrun=True, direct=False, log_dryrun=log)
 
+        shutil.rmtree(self._exp_dir)
+
     def run(
         self,
         sequential: bool = False,

--- a/src/nemo_run/run/job.py
+++ b/src/nemo_run/run/job.py
@@ -92,6 +92,7 @@ class Job(ConfigurableMixin):
         )
 
     def prepare(self):
+        self.executor.create_job_dir()
         self._executable = package(
             self.id, self.task, executor=self.executor, serialize_to_file=True
         )
@@ -306,6 +307,7 @@ class JobGroup(ConfigurableMixin):
         )
 
     def prepare(self):
+        self.executor.create_job_dir()
         self._executables: list[tuple[AppDef, Executor]] = []
         for i, task in enumerate(self.tasks):
             executor = self.executors if self._merge else self.executors[i]  # type: ignore

--- a/test/core/execution/test_local.py
+++ b/test/core/execution/test_local.py
@@ -37,7 +37,7 @@ def test_local_executor_assign():
 
         assert executor.experiment_id == "test_exp"
         assert executor.job_dir == os.path.join(tmp_dir, "test_task")
-        assert os.path.exists(executor.job_dir)
+        assert not os.path.exists(executor.job_dir)
 
 
 def test_local_executor_nnodes():


### PR DESCRIPTION
This PR solves two problems:

1. Before, experiment and job config was being persisted to disk even if `exp.run` was not called. This created unnecessary directories and made it harder to track down experiments that actually ran. Now, it persists information only when `exp.run` is called thus eliminating noise.

2. Before, `_save_jobs` was called after every `exp.add` and after every job launch. This is unnecessary and increases io times for experiments that have thousands of jobs. Now we only call `_save_jobs` twice. Once at the start of `exp.run` and once at the end. This will be followed by a PR that cancels all submitted jobs if `exp.run` fails midway.