### PR TITLE
zozhang/dgxc executor data mover 

### DIFF
--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -108,8 +108,6 @@ class DGXCloudExecutor(Executor):
             cmd = f"rm -rf {dest_path} && mkdir -p {dest_path} && echo {encoded_data} | base64 -d > {dest_path}/archive.tar.gz && tar -xzf {dest_path}/archive.tar.gz -C {dest_path} && rm {dest_path}/archive.tar.gz"
             return cmd
 
-        raise RuntimeError("Failed to generate data movement command")
-
     def create_data_mover_workload(self, token: str, project_id: str, cluster_id: str):
         """
         Creates a CPU only workload to move job directory into PVC using the provided project/cluster IDs.

--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -114,7 +114,7 @@ class DGXCloudExecutor(Executor):
             # Encode the tarball data to base64
             encoded_data = base64.b64encode(file_data).decode("utf-8")
 
-            # Delete and recreate directory if it exists already, command to decode base64 data, save to a file, and extract inside the pod
+            # Delete and recreate directory if it already exists, command to decode base64 data, save to a file, and extract inside the pod
             cmd = f"rm -rf {dest_path} && mkdir -p {dest_path} && echo {encoded_data} | base64 -d > {dest_path}/archive.tar.gz && tar -xzf {dest_path}/archive.tar.gz -C {dest_path} && rm {dest_path}/archive.tar.gz"
             return cmd
 
@@ -122,7 +122,7 @@ class DGXCloudExecutor(Executor):
         self, token: str, project_id: str, cluster_id: str, name: str
     ):
         """
-        Creates an cpu only workload to move project directory into PVC using the provided project/cluster IDs.
+        Creates an cpu only workload to move job directory into PVC using the provided project/cluster IDs.
         """
 
         cmd=self.copy_directory_data_command(self.job_dir, self.pvc_job_dir)
@@ -353,8 +353,8 @@ cd /nemo_run/code
         self.experiment_dir = exp_dir
         self.job_dir = os.path.join(exp_dir, task_dir)
         
-        ## setting linked PVC experiment and job directories 
-        job_subdir = self.job_dir[len(get_nemorun_home())+1:] #+1 to remove the initial backslash
+        # setting linked PVC job directory
+        job_subdir = self.job_dir[len(get_nemorun_home())+1:] # +1 to remove the initial backslash
         self.pvc_job_dir = os.path.join(self.pvc_nemo_run_dir, job_subdir)
 
         logger.info(

--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -55,6 +55,7 @@ class DGXCloudExecutor(Executor):
     project_name: str
     container_image: str
     pvc_nemo_run_dir: str
+    launched_from_cluster: bool = False
     nodes: int = 1
     gpus_per_node: int = 0
     nprocs_per_node: int = 1
@@ -251,9 +252,10 @@ cd /nemo_run/code
 """
         with open(os.path.join(self.job_dir, "launch_script.sh"), "w+") as f:
             f.write(launch_script)
-
-        logger.info("Creating data movement workload")
-        self.move_data(token, project_id, cluster_id)
+        
+        if not self.launched_from_cluster:
+            logger.info("Creating data movement workload")
+            self.move_data(token, project_id, cluster_id)
 
         logger.info("Creating distributed workload")
         resp = self.create_distributed_job(token, project_id, cluster_id, name)

--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -361,6 +361,11 @@ cd /nemo_run/code
         )
         self.experiment_id = exp_id
 
+    def get_launcher_prefix(self) -> Optional[list[str]]:
+        launcher = self.get_launcher()
+        if launcher.nsys_profile:
+            return launcher.get_nsys_prefix(profile_dir="/nemo_run")
+
     def package_configs(self, *cfgs: tuple[str, str]) -> list[str]:
         filenames = []
         basepath = os.path.join(self.job_dir, "configs")

--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -258,16 +258,15 @@ cd /nemo_run/code
 
         logger.info("Creating data movement workload")
         self.move_data(token, project_id, cluster_id)
-        return "", ""
 
-        # logger.info("Creating distributed workload")
-        # resp = self.create_distributed_job(token, project_id, cluster_id, name)
-        # if resp.status_code not in [200, 202]:
-        #     raise RuntimeError(f"Failed to create job, status_code={resp.status_code}")
+        logger.info("Creating distributed workload")
+        resp = self.create_distributed_job(token, project_id, cluster_id, name)
+        if resp.status_code not in [200, 202]:
+            raise RuntimeError(f"Failed to create job, status_code={resp.status_code}")
 
-        # r_json = resp.json()
-        # job_id = r_json["workloadId"]
-        # status = r_json["actualPhase"]
+        r_json = resp.json()
+        job_id = r_json["workloadId"]
+        status = r_json["actualPhase"]
         return job_id, status
 
     def nnodes(self) -> int:

--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -201,6 +201,7 @@ class DGXCloudExecutor(Executor):
         """
         url = f"{self.base_url}/workloads/distributed"
         headers = self._default_headers(token=token)
+        ##do we need to include this as a script? this could be in the command instead
         launch_script = f"""
 ln -s {self.job_dir} /nemo_run
 cd /nemo_run/code
@@ -329,6 +330,9 @@ cd /nemo_run/code
         self.experiment_dir = exp_dir
         self.job_dir = os.path.join(exp_dir, task_dir)
         self.experiment_id = exp_id
+
+        ## TODO: need to figure out how to track location of data in PVC and in the local environment 
+
         assert any(
             map(
                 lambda x: os.path.commonpath(

--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -96,7 +96,7 @@ class DGXCloudExecutor(Executor):
                 break
         return project_id, cluster_id
 
-    def copy_directory_data_command(self, local_dir_path, dest_path) -> str:
+    def copy_directory_data_command(self, local_dir_path: str, dest_path: str) -> str:
         with tempfile.TemporaryDirectory() as temp_dir:
             tarball_path = os.path.join(temp_dir, "archive.tar.gz")
             subprocess.run(f"tar -czf {tarball_path} -C {local_dir_path} .", shell=True, check=True)
@@ -171,7 +171,12 @@ class DGXCloudExecutor(Executor):
         workload_id = resp_json["workloadId"]
         status = DGXCloudState(resp_json["actualPhase"])
 
-        while status in [DGXCloudState.PENDING, DGXCloudState.CREATING, DGXCloudState.INITIALIZING, DGXCloudState.RUNNING]:
+        while status in [
+            DGXCloudState.PENDING,
+            DGXCloudState.CREATING,
+            DGXCloudState.INITIALIZING,
+            DGXCloudState.RUNNING,
+        ]:
             time.sleep(sleep)
             status = self.status(workload_id)
 
@@ -347,9 +352,7 @@ cd /nemo_run/code
 
         # setting linked PVC job directory
         nemo_run_home = get_nemorun_home()
-        job_subdir = self.job_dir[
-            len(nemo_run_home) + 1 :
-        ]  # +1 to remove the initial backslash
+        job_subdir = self.job_dir[len(nemo_run_home) + 1 :]  # +1 to remove the initial backslash
         self.pvc_job_dir = os.path.join(self.pvc_nemo_run_dir, job_subdir)
 
         logger.info(

--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -252,7 +252,7 @@ cd /nemo_run/code
 """
         with open(os.path.join(self.job_dir, "launch_script.sh"), "w+") as f:
             f.write(launch_script)
-        
+
         if not self.launched_from_cluster:
             logger.info("Creating data movement workload")
             self.move_data(token, project_id, cluster_id)

--- a/nemo_run/run/torchx_backend/schedulers/dgxcloud.py
+++ b/nemo_run/run/torchx_backend/schedulers/dgxcloud.py
@@ -87,7 +87,7 @@ class DGXCloudScheduler(SchedulerMixin, Scheduler[dict[str, str]]):  # type: ign
         cfg: Executor,
     ) -> AppDryRunInfo[DGXRequest]:
         assert isinstance(cfg, DGXCloudExecutor), (
-            f"{cfg.__class__} not supported for skypilot scheduler."
+            f"{cfg.__class__} not supported for DGXCloud scheduler."
         )
         executor = cfg
 

--- a/test/run/torchx_backend/schedulers/test_dgxcloud.py
+++ b/test/run/torchx_backend/schedulers/test_dgxcloud.py
@@ -42,6 +42,7 @@ def dgx_cloud_executor():
         app_secret="test_secret",
         project_name="test_project",
         container_image="nvcr.io/nvidia/test:latest",
+        pvc_nemo_run_dir="/workspace/nemo_run",
         job_dir=tempfile.mkdtemp(),
     )
 
@@ -151,6 +152,7 @@ def test_save_and_get_job_dirs():
             project_name="test_project",
             container_image="test:latest",
             job_dir=temp_dir,
+            pvc_nemo_run_dir="/workspace/nemo_run",
         )
 
         _save_job_dir("test_app_id", "RUNNING", executor)


### PR DESCRIPTION
This PR creates a `move_data `function that moves the local job directory into a PVC before launching a job. This removes the need to launch jobs from inside the DGXC Cluster. 

- adds a data movement step which moves data to an indicated PVC path before launching jobs using the DGXC Executor
      - this creates a cpu only workload, zips and moves the data and then deletes the workload for cleanliness
- modifies the `status` function to use the workloads api instead of the distributed training specific api path 
- modifies the package configs to use the` /nemo_run/configs` as the path similar to Skyhook and Slurm 
- moves the creation of the `launch_script ` into the `launch` function before data movement 
- adds `pvc_nemo_run_dir` and `pvc_job_dir` variables

