### PR TITLE
Add include_uncommitted and include_untracked options to GitArchivePackager

### DIFF
--- a/nemo_run/core/packaging/git.py
+++ b/nemo_run/core/packaging/git.py
@@ -41,9 +41,9 @@ class GitArchivePackager(Packager):
     #. This extracted tar file becomes the working directory for your job.
 
     .. note::
-        git archive will only package code committed in the specified ref.
-        Any uncommitted code will not be packaged.
-        We are working on adding an option to package uncommitted code but it is not ready yet.
+        By default, git archive will only package code committed in the specified ref.
+        You can use include_uncommitted=True and include_untracked=True to package
+        uncommitted changes and untracked files respectively.
     """
 
     basepath: str = ""
@@ -71,6 +71,12 @@ class GitArchivePackager(Packager):
 
     check_uncommitted_changes: bool = False
     check_untracked_files: bool = False
+
+    #: Include uncommitted changes in the archive
+    include_uncommitted: bool = False
+
+    #: Include untracked files in the archive
+    include_untracked: bool = False
 
     def package(self, path: Path, job_dir: str, name: str) -> str:
         output_file = os.path.join(job_dir, f"{name}.tar.gz")
@@ -132,6 +138,139 @@ class GitArchivePackager(Packager):
             ctx.run(git_archive_cmd)
             if self.include_submodules:
                 ctx.run(git_submodule_cmd)
+
+        # Handle uncommitted changes
+        if self.include_uncommitted:
+            unstaged_file_id = uuid.uuid4()
+            unstaged_tar_file = f"unstaged_{unstaged_file_id}.tmp"
+
+            with ctx.cd(git_base_path):
+                # Get the list of files with unstaged changes
+                changed_files = (
+                    subprocess.run(
+                        "git diff --name-only", shell=True, capture_output=True, text=True
+                    )
+                    .stdout.strip()
+                    .split("\n")
+                )
+
+                if changed_files and changed_files[0]:  # Check if non-empty
+                    # Filter files in subpath if specified
+                    if self.subpath:
+                        prefix_len = len(self.subpath.rstrip("/")) + 1  # +1 for the slash
+                        filtered_files = []
+                        for f in changed_files:
+                            if f.startswith(self.subpath):
+                                filtered_files.append(f)
+                        changed_files = filtered_files
+
+                    if changed_files:
+                        # Create the tarfile in the right way based on subpath
+                        if self.subpath:
+                            # We need to change to the subpath dir and create the tar without the prefix
+                            subpath_dir = os.path.join(git_base_path, self.subpath)
+
+                            # Create list of files relative to the subpath
+                            relative_files = []
+                            for f in changed_files:
+                                relative_files.append(
+                                    os.path.relpath(os.path.join(git_base_path, f), subpath_dir)
+                                )
+
+                            # Create tar from the subpath directory
+                            tar_path = os.path.join(git_base_path, unstaged_tar_file)
+                            with ctx.cd(subpath_dir):
+                                if relative_files:  # Only create tar if there are files
+                                    ctx.run(f"tar -cf {tar_path} {' '.join(relative_files)}")
+                                else:
+                                    # Create empty tar file to avoid errors
+                                    ctx.run(f"tar -cf {tar_path} --files-from /dev/null")
+                        else:
+                            # No subpath, create tar from the git base path
+                            if changed_files:  # Only create tar if there are files
+                                ctx.run(f"tar -cf {unstaged_tar_file} {' '.join(changed_files)}")
+                            else:
+                                # Create empty tar file to avoid errors
+                                ctx.run(f"tar -cf {unstaged_tar_file} --files-from /dev/null")
+
+                        # Add to the main archive - use a more compatible approach
+                        # Instead of using 'tar Af', use the extract-and-create approach for all platforms
+                        temp_dir = f"temp_extract_unstaged_{unstaged_file_id}"
+                        ctx.run(f"mkdir -p {temp_dir}")
+                        ctx.run(f"tar xf {output_file}.tmp -C {temp_dir}")
+                        ctx.run(f"tar xf {unstaged_tar_file} -C {temp_dir}")
+                        ctx.run(f"tar cf {output_file}.tmp -C {temp_dir} .")
+                        ctx.run(f"rm -rf {temp_dir}")
+                        ctx.run(f"rm {unstaged_tar_file}")
+
+        # Handle untracked files
+        if self.include_untracked:
+            untracked_file_id = uuid.uuid4()
+            untracked_tar_file = f"untracked_{untracked_file_id}.tmp"
+
+            with ctx.cd(git_base_path):
+                # Get the list of untracked files
+                untracked_files = (
+                    subprocess.run(
+                        "git ls-files --others --exclude-standard",
+                        shell=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    .stdout.strip()
+                    .split("\n")
+                )
+
+                if untracked_files and untracked_files[0]:  # Check if non-empty
+                    # Filter files in subpath if specified
+                    if self.subpath:
+                        prefix_len = len(self.subpath.rstrip("/")) + 1  # +1 for the slash
+                        filtered_files = []
+                        for f in untracked_files:
+                            if f.startswith(self.subpath):
+                                filtered_files.append(f)
+                        untracked_files = filtered_files
+
+                    if untracked_files:
+                        # Create the tarfile in the right way based on subpath
+                        if self.subpath:
+                            # We need to change to the subpath dir and create the tar without the prefix
+                            subpath_dir = os.path.join(git_base_path, self.subpath)
+
+                            # Create list of files relative to the subpath
+                            relative_files = []
+                            for f in untracked_files:
+                                relative_files.append(
+                                    os.path.relpath(os.path.join(git_base_path, f), subpath_dir)
+                                )
+
+                            # Create tar from the subpath directory
+                            tar_path = os.path.join(git_base_path, untracked_tar_file)
+                            with ctx.cd(subpath_dir):
+                                if relative_files:  # Only create tar if there are files
+                                    ctx.run(f"tar -cf {tar_path} {' '.join(relative_files)}")
+                                else:
+                                    # Create empty tar file to avoid errors
+                                    ctx.run(f"tar -cf {tar_path} --files-from /dev/null")
+                        else:
+                            # No subpath, create tar from the git base path
+                            if untracked_files:  # Only create tar if there are files
+                                ctx.run(f"tar -cf {untracked_tar_file} {' '.join(untracked_files)}")
+                            else:
+                                # Create empty tar file to avoid errors
+                                ctx.run(f"tar -cf {untracked_tar_file} --files-from /dev/null")
+
+                        # Add to the main archive - use a more compatible approach
+                        # Instead of using 'tar Af', use the extract-and-create approach for all platforms
+                        temp_dir = f"temp_extract_untracked_{untracked_file_id}"
+                        ctx.run(f"mkdir -p {temp_dir}")
+                        ctx.run(f"tar xf {output_file}.tmp -C {temp_dir}")
+                        ctx.run(f"tar xf {untracked_tar_file} -C {temp_dir}")
+                        ctx.run(f"tar cf {output_file}.tmp -C {temp_dir} .")
+                        ctx.run(f"rm -rf {temp_dir}")
+                        ctx.run(f"rm {untracked_tar_file}")
+
+        # Process include_pattern files
         if isinstance(self.include_pattern, str):
             self.include_pattern = [self.include_pattern]
 


### PR DESCRIPTION
This PR adds two new features to the `GitArchivePackager`:
- `include_uncommitted`: Option to include uncommitted changes in the packaged archive
- `include_untracked`: Option to include untracked files in the packaged archive

## Purpose
By default, `git archive` only includes committed files in the specified Git reference. These new options allow users to package their working state including uncommitted changes and untracked files, which is useful for development and testing scenarios where the user wants to package their current work-in-progress state.

## Features

### include_uncommitted
When set to `True`, uncommitted changes to tracked files will be included in the archive. This captures modifications that haven't been committed yet.

```python
# Example: Include uncommitted changes
packager = GitArchivePackager(ref="HEAD", include_uncommitted=True)
```

### include_untracked
When set to `True`, untracked files will be included in the archive. This captures new files that haven't been added to git yet.

```python
# Example: Include untracked files
packager = GitArchivePackager(ref="HEAD", include_untracked=True)
```

### Combined usage
Both options can be used together to capture the complete working state:

```python
# Example: Include both uncommitted changes and untracked files
packager = GitArchivePackager(
    ref="HEAD", 
    include_uncommitted=True, 
    include_untracked=True
)
```

## Implementation Details
- Implemented using `git diff --name-only` to find uncommitted changes
- Implemented using `git ls-files --others --exclude-standard` to find untracked files
- Works correctly with the `subpath` option, only including uncommitted/untracked files within the specified subpath
- Compatible with both Linux and non-Linux platforms

## Testing
Added comprehensive tests to verify all functionality:
- Test for uncommitted changes only
- Test for untracked files only
- Test for both uncommitted and untracked together
- Test with subpath to verify path handling
