### PR TITLE
Add sbatch network arg

### DIFF
--- a/nemo_run/core/execution/slurm.py
+++ b/nemo_run/core/execution/slurm.py
@@ -340,6 +340,7 @@ class SlurmExecutor(Executor):
     setup_lines: Optional[str] = None
     het_group_indices: Optional[list[int]] = None
     segment: Optional[int] = None
+    network: Optional[str] = None
 
     #: Set by the executor; cannot be initialized
     job_name: str = field(init=False, default="nemo-job")


### PR DESCRIPTION
Example for setting `#SBATCH --network=sharp`
```python
    executor = run.SlurmExecutor(
        account=account,
        partition=partition,
        tunnel=run.LocalTunnel(
            job_dir=os.path.join(log_dir, "experiments"),
        ),
        nodes=nodes,
        ntasks_per_node=num_gpus_per_node,
        container_image=container_image,
        container_mounts=mounts,
        env_vars=env_vars,
        srun_args=srun_args,
        time=time_limit,
        mem="0",
        exclusive=True,
        packager=run.GitArchivePackager(),
        segment=segment,
        network="sharp",
    )
```