### PR TITLE
change the create dist job functionn to support creating a single nod…

### DIFF
--- a/nemo_run/core/execution/dgxcloud.py
+++ b/nemo_run/core/execution/dgxcloud.py
@@ -202,7 +202,9 @@ class DGXCloudExecutor(Executor):
                 resp.text,
             )
 
-    def create_training_job(self, token: str, project_id: str, cluster_id: str, name: str) -> requests.Response:
+    def create_training_job(
+        self, token: str, project_id: str, cluster_id: str, name: str
+    ) -> requests.Response:
         """
         Creates a training job on DGX Cloud using the provided project/cluster IDs.
         For multi-node jobs, creates a distributed workload. Otherwise creates a single-node training.
@@ -255,16 +257,10 @@ class DGXCloudExecutor(Executor):
                 "numWorkers": self.nodes,
             }
 
-            payload = {
-                **common_payload,
-                "spec": {**common_spec, **distributed_spec}
-            }
+            payload = {**common_payload, "spec": {**common_spec, **distributed_spec}}
         else:
             url = f"{self.base_url}/workloads/trainings"
-            payload = {
-                **common_payload,
-                "spec": common_spec
-            }
+            payload = {**common_payload, "spec": common_spec}
 
         headers = self._default_headers(token=token)
         response = requests.post(url, json=payload, headers=headers)

--- a/test/core/execution/test_dgxcloud.py
+++ b/test/core/execution/test_dgxcloud.py
@@ -334,7 +334,7 @@ class TestDGXCloudExecutor:
         mock_status.assert_called()
 
     @patch("requests.post")
-    def test_create_distributed_job(self, mock_post):
+    def test_create_training_job(self, mock_post):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = '{"status": "submitted"}'
@@ -354,7 +354,7 @@ class TestDGXCloudExecutor:
         executor.pvc_job_dir = "/workspace/nemo_run/job_dir"
         executor.env_vars = {"TEST_VAR": "test_value"}
 
-        response = executor.create_distributed_job(
+        response = executor.create_training_job(
             token="test_token",
             project_id="proj_id",
             cluster_id="cluster_id",
@@ -385,7 +385,7 @@ class TestDGXCloudExecutor:
     @patch.object(DGXCloudExecutor, "get_auth_token")
     @patch.object(DGXCloudExecutor, "get_project_and_cluster_id")
     @patch.object(DGXCloudExecutor, "move_data")
-    @patch.object(DGXCloudExecutor, "create_distributed_job")
+    @patch.object(DGXCloudExecutor, "create_training_job")
     def test_launch_success(self, mock_create_job, mock_move_data, mock_get_ids, mock_get_token):
         mock_get_token.return_value = "test_token"
         mock_get_ids.return_value = ("proj_id", "cluster_id")
@@ -455,7 +455,7 @@ class TestDGXCloudExecutor:
     @patch.object(DGXCloudExecutor, "get_auth_token")
     @patch.object(DGXCloudExecutor, "get_project_and_cluster_id")
     @patch.object(DGXCloudExecutor, "move_data")
-    @patch.object(DGXCloudExecutor, "create_distributed_job")
+    @patch.object(DGXCloudExecutor, "create_training_job")
     def test_launch_job_creation_failed(
         self, mock_create_job, mock_move_data, mock_get_ids, mock_get_token
     ):


### PR DESCRIPTION
This pull request refactors the `create_distributed_job` method to a more general-purpose `create_training_job` method in the `DGXCloudExecutor` class, improving functionality and clarity. It also updates related test cases to align with the new method.
closes #239 

### Core functionality changes:

* Renamed `create_distributed_job` to `create_training_job` in `nemo_run/core/execution/dgxcloud.py`, adding support for both single-node and multi-node training jobs on DGX Cloud. The method now validates inputs, determines the appropriate endpoint based on node count, and constructs payloads accordingly.
* Updated the `launch` method to call the new `create_training_job` method instead of the old `create_distributed_job`.

### Test updates:

* Renamed and updated the test method `test_create_distributed_job` to `test_create_training_job` in `test/core/execution/test_dgxcloud.py` to reflect the new method name. [[1]](diffhunk://#diff-ea38463b3946366296f25488ea61f6ae162830b426b399a566b3f404bd0dca97L337-R337) [[2]](diffhunk://#diff-ea38463b3946366296f25488ea61f6ae162830b426b399a566b3f404bd0dca97L357-R357)
* Updated test cases that previously mocked `create_distributed_job` to mock `create_training_job` instead, ensuring compatibility with the refactored method. [[1]](diffhunk://#diff-ea38463b3946366296f25488ea61f6ae162830b426b399a566b3f404bd0dca97L388-R388) [[2]](diffhunk://#diff-ea38463b3946366296f25488ea61f6ae162830b426b399a566b3f404bd0dca97L458-R458)