### PR TITLE
[SkyPilot] Update YAML dump imports + backward compatibility for SkyPilot <=0.10.3

### DIFF
--- a/nemo_run/core/execution/skypilot.py
+++ b/nemo_run/core/execution/skypilot.py
@@ -389,11 +389,17 @@ cd /nemo_run/code
         dryrun: bool = False,
     ) -> tuple[Optional[int], Optional["backends.ResourceHandle"]]:
         from sky import backends, launch, stream_and_get
-        from sky.utils import common_utils
+
+        # Backward compatibility for SkyPilot 0.10.3+
+        # dump_yaml_str moved from sky.utils.common_utils to yaml_utils
+        try:
+            from sky.utils import yaml_utils
+        except ImportError:
+            from sky.utils import common_utils as yaml_utils
 
         task_yml = os.path.join(self.job_dir, "skypilot_task.yml")
         with open(task_yml, "w+") as f:
-            f.write(common_utils.dump_yaml_str(task.to_yaml_config()))
+            f.write(yaml_utils.dump_yaml_str(task.to_yaml_config()))
 
         backend = backends.CloudVmRayBackend()
         if num_nodes:


### PR DESCRIPTION
SkyPilot 0.10.3 moved dump_yaml_str from `sky.utils.common_utils` to `sky.utils.yaml_utils` in https://github.com/skypilot-org/skypilot/commit/c932c1b93985feb9c0417c498df6d4feaf6a0863. This PR adds a fallback for YAML dumping if an older SkyPilot version is detected.

Alternative to this PR could be to pin the SkyPilot version to >=0.10.3 and always use `from sky.utils import yaml_utils`, but I'll let the Nemo Run maintainers take the call on that. 