### PR TITLE
[SkyPilot] Add retry_until_up as an optional arg to SkyPilot Executor

### DIFF
--- a/nemo_run/core/execution/skypilot.py
+++ b/nemo_run/core/execution/skypilot.py
@@ -107,6 +107,7 @@ class SkypilotExecutor(Executor):
     cluster_config_overrides: Optional[dict[str, Any]] = None
     infra: Optional[str] = None
     network_tier: Optional[str] = None
+    retry_until_up: bool = False
     packager: Packager = field(default_factory=lambda: GitArchivePackager())  # type: ignore  # noqa: F821
 
     def __post_init__(self):
@@ -410,7 +411,7 @@ cd /nemo_run/code
                 idle_minutes_to_autostop=self.idle_minutes_to_autostop,
                 down=self.autodown,
                 fast=True,
-                # retry_until_up=retry_until_up,
+                retry_until_up=self.retry_until_up,
                 # clone_disk_from=clone_disk_from,
             )
         )


### PR DESCRIPTION
This PR adds a configurable `retry_until_up` parameter to the `SkypilotExecutor` class, allowing users to control whether SkyPilot should retry launching clusters indefinitely when they fail to come up.

## Why is this needed
If the users' clusters are full, they may want to queue their jobs and wait till resources become available. This change enables users to queue their launches indefinitely by setting retry_until_up=True when initializing the executor. This is particularly useful for long-running experiments that can tolerate delayed starts and scenarios where compute resources are scarce and users want to wait for availability.

## Discussion
There's open questions about how to handle ctrl+c and cancelling `sky launch` requests through nemo run. Current behavior appears to be `nemo experiment cancel` just cancels the task, but does not `sky down` the cluster. When coupled with `retry_until_up=True`, the sky launch request may keep running indefinitely and will need to be manually terminated with `sky down` or a `sky api cancel`.

We may want to have `sky down` run when `nemo experiment cancel` is run, but that seems like a issue independent of this PR so I'll let the Nemo Run maintainers take a call on this.