### PR TITLE
fix(typo): exit_code prints empty

### DIFF
--- a/nemo_run/core/execution/templates/slurm.sh.j2
+++ b/nemo_run/core/execution/templates/slurm.sh.j2
@@ -73,7 +73,7 @@ while ! $all_done; do
             # Process is no longer running => check its exit status.
             wait "$pid"
             exitcode=$?
-            echo "Process $pid exited with code $exit_code at $(date '+%Y-%m-%d %H:%M:%S')"
+            echo "Process $pid exited with code $exitcode at $(date '+%Y-%m-%d %H:%M:%S')"
             # Wait a bit (to get a clean stack trace in case there is one being generated), then kill the
             # remaining processes if needed.
             sleep {{monitor_group_job_wait_time}}

--- a/test/core/execution/artifacts/ft_het_slurm.sh
+++ b/test/core/execution/artifacts/ft_het_slurm.sh
@@ -105,7 +105,7 @@ while ! $all_done; do
             # Process is no longer running => check its exit status.
             wait "$pid"
             exitcode=$?
-            echo "Process $pid exited with code $exit_code at $(date '+%Y-%m-%d %H:%M:%S')"
+            echo "Process $pid exited with code $exitcode at $(date '+%Y-%m-%d %H:%M:%S')"
             # Wait a bit (to get a clean stack trace in case there is one being generated), then kill the
             # remaining processes if needed.
             sleep 60

--- a/test/core/execution/artifacts/group_resource_req_slurm.sh
+++ b/test/core/execution/artifacts/group_resource_req_slurm.sh
@@ -65,7 +65,7 @@ while ! $all_done; do
             # Process is no longer running => check its exit status.
             wait "$pid"
             exitcode=$?
-            echo "Process $pid exited with code $exit_code at $(date '+%Y-%m-%d %H:%M:%S')"
+            echo "Process $pid exited with code $exitcode at $(date '+%Y-%m-%d %H:%M:%S')"
             # Wait a bit (to get a clean stack trace in case there is one being generated), then kill the
             # remaining processes if needed.
             sleep 60

--- a/test/core/execution/artifacts/group_slurm.sh
+++ b/test/core/execution/artifacts/group_slurm.sh
@@ -58,7 +58,7 @@ while ! $all_done; do
             # Process is no longer running => check its exit status.
             wait "$pid"
             exitcode=$?
-            echo "Process $pid exited with code $exit_code at $(date '+%Y-%m-%d %H:%M:%S')"
+            echo "Process $pid exited with code $exitcode at $(date '+%Y-%m-%d %H:%M:%S')"
             # Wait a bit (to get a clean stack trace in case there is one being generated), then kill the
             # remaining processes if needed.
             sleep 60

--- a/test/core/execution/artifacts/het_slurm.sh
+++ b/test/core/execution/artifacts/het_slurm.sh
@@ -80,7 +80,7 @@ while ! $all_done; do
             # Process is no longer running => check its exit status.
             wait "$pid"
             exitcode=$?
-            echo "Process $pid exited with code $exit_code at $(date '+%Y-%m-%d %H:%M:%S')"
+            echo "Process $pid exited with code $exitcode at $(date '+%Y-%m-%d %H:%M:%S')"
             # Wait a bit (to get a clean stack trace in case there is one being generated), then kill the
             # remaining processes if needed.
             sleep 60


### PR DESCRIPTION
Just a typo which prints empty code messages for slurm 