### PR TITLE
docs: Fix broken links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,9 @@ If all tests passed, then you should be good to get started with the development
 The repository is home to flexible Python modules, sample scripts, tests, and more.
 Here is a brief overview of where everything lives:
 
-- [docker](docker/) - Dockerfiles to build NeMo with NeMo Run.
 - [docs](docs/) - Walkthroughs and guides the library.
 - [examples](examples/) - Examples for how users may want to use NeMo Run.
-- [src](src/) -
-  - [nemo_run](src/nemo_run/) - The source code for NeMo Run.
+- [nemo_run](nemo_run/) - The source code for NeMo Run.
 - [test](test/) - Unit tests.
 
 ## Examples and Documentation
@@ -65,7 +63,7 @@ Run the following commands to switch to the project documentation folder and gen
 
 ```sh
 cd docs/
-uv run --group docs sphinx-build source/ _build/html
+uv run --group docs sphinx-build . _build/html
 ```
 
 The resulting HTML files are generated in a `_build/html` folder created under the project `docs/` folder.

--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ You can find the tutorial series below:
 Please see the [contribution guide](./CONTRIBUTING.md) to contribute to NeMo Run.
 
 ## FAQs
-Please find a list of frequently asked questions [here](./docs/source/faqs.md).
+Please find a list of frequently asked questions [here](./docs/faqs.md).


### PR DESCRIPTION
- Fix FAQs link in `README.md`
- Fix `sphinx-build` command in `CONTRIBUTING.md`: change `source/` to `.` to match actual docs structure
- Remove reference to non-existent `docker/` directory in `CONTRIBUTING.md`
- Update `src/nemo_run/` reference to `nemo_run/` to match actual directory structure