### PR TITLE
Set container_env for slurm sbatch when using env_vars

### DIFF
--- a/nemo_run/core/execution/slurm.py
+++ b/nemo_run/core/execution/slurm.py
@@ -983,6 +983,10 @@ class SlurmBatchRequest:
 
                 group_env_vars.append(current_env_vars)
 
+                _container_env = set(resource_req.container_env or [])
+                _container_env.update(full_env_vars.keys())
+                _container_env.update(resource_req.env_vars.keys())
+
                 _container_flags = get_container_flags(
                     base_mounts=resource_req.container_mounts,
                     src_job_dir=os.path.join(
@@ -990,7 +994,7 @@ class SlurmBatchRequest:
                         job_directory_name,
                     ),
                     container_image=resource_req.container_image,
-                    container_env=resource_req.container_env,
+                    container_env=sorted(_container_env),
                 )
                 _srun_args = ["--wait=60", "--kill-on-bad-exit=1"]
                 _srun_args.extend(resource_req.srun_args or [])
@@ -999,6 +1003,10 @@ class SlurmBatchRequest:
                 cmd_stderr = stderr_flags.copy()
                 if cmd_stderr:
                     cmd_stderr[-1] = cmd_stderr[-1].replace(original_job_name, self.jobs[group_ind])
+
+                _container_env = set(self.executor.container_env or [])
+                _container_env.update(full_env_vars.keys())
+
                 _container_flags = get_container_flags(
                     base_mounts=self.executor.container_mounts,
                     src_job_dir=os.path.join(
@@ -1006,7 +1014,7 @@ class SlurmBatchRequest:
                         job_directory_name,
                     ),
                     container_image=self.executor.container_image,
-                    container_env=self.executor.container_env,
+                    container_env=sorted(_container_env),
                 )
                 _srun_args = ["--wait=60", "--kill-on-bad-exit=1"]
                 _srun_args.extend(self.executor.srun_args or [])


### PR DESCRIPTION
For slurm sbatch workloads set container-env flag for any variable set via env_vars.

The pyxis/enroot defaults are to set all variables in the user environment in the container environment, except when that variable already exists in the container. Then it won't overwrite it unless '--container-env=VAR' is set.

This creates potential confusion for the end-user 1) Most aren't aware of this, 2) It's a harder to reason about bug as some of your variables get set the way you want but not all.

My proposal is we set pass any variables the user set via env_vars to the '--container-env' flag as that's likely what the user expects.