### PR TITLE
fix: remove unexpected side effect in get_srun_flags

### DIFF
--- a/nemo_run/run/ray/slurm.py
+++ b/nemo_run/run/ray/slurm.py
@@ -203,15 +203,13 @@ class SlurmRayRequest:
             if gres_specification:
                 _srun_flags.append(gres_specification)
 
+            new_mounts = copy.deepcopy(mounts)
             if self.nemo_run_dir:
-                new_mounts = copy.deepcopy(mounts)
                 for i, mount in enumerate(new_mounts):
                     if mount.startswith(RUNDIR_SPECIAL_NAME):
                         new_mounts[i] = mount.replace(RUNDIR_SPECIAL_NAME, self.nemo_run_dir, 1)
 
                 new_mounts.append(f"{self.nemo_run_dir}:/{RUNDIR_NAME}")
-            else:
-                new_mounts = mounts
 
             new_mounts.append(f"{self.cluster_dir}:{self.cluster_dir}")
             new_mounts.append(f"{logs_dir}:{logs_dir}")


### PR DESCRIPTION
Currently, if `nemo_run_dir` is falsy, this function will append mounts to the `self.executor.container_mounts` list, resulting in unexpected extension of the list with every call.

This function is called by materialize, which it turns out is even called by the `__repr__` of `SlurmRayRequest` and as such one would expect it not to have any side effects (especially since the name of the offending function suggests its a getter).

Found while debugging an issue that turned out to not be caused by NeMo Run, but finding increasing number of duplicate mounts as my debugger helpfully displayed the repr of the class when I was looking at it.

Considering how simple the fix is (and that I already tested it locally when trying to debug the issue) I decided not to create an issue before this PR, hopefully that's acceptable here.