### PR TITLE
feat: use slurm executor to get ray template name

### DIFF
--- a/nemo_run/core/execution/slurm.py
+++ b/nemo_run/core/execution/slurm.py
@@ -344,6 +344,8 @@ class SlurmExecutor(Executor):
     het_group_indices: Optional[list[int]] = None
     segment: Optional[int] = None
     network: Optional[str] = None
+    #: Template name to use for Ray jobs (e.g., "ray.sub.j2" or "ray_enroot.sub.j2")
+    ray_template: str = "ray.sub.j2"
 
     #: Set by the executor; cannot be initialized
     job_name: str = field(init=False, default="nemo-job")

--- a/nemo_run/run/torchx_backend/schedulers/slurm.py
+++ b/nemo_run/run/torchx_backend/schedulers/slurm.py
@@ -50,7 +50,12 @@ from torchx.specs import (
 )
 from torchx.specs.api import is_terminal
 
-from nemo_run.config import RUNDIR_NAME, USE_WITH_RAY_CLUSTER_KEY, from_dict, get_nemorun_home
+from nemo_run.config import (
+    RUNDIR_NAME,
+    USE_WITH_RAY_CLUSTER_KEY,
+    from_dict,
+    get_nemorun_home,
+)
 from nemo_run.core.execution.base import Executor
 from nemo_run.core.execution.slurm import SlurmBatchRequest, SlurmExecutor, SlurmJobDetails
 from nemo_run.core.tunnel.client import LocalTunnel, PackagingJob, SSHTunnel, Tunnel
@@ -125,8 +130,8 @@ class SlurmTunnelScheduler(SchedulerMixin, SlurmScheduler):  # type: ignore
                     )
 
             command = [app.roles[0].entrypoint] + app.roles[0].args
-            # Allow selecting Ray template via environment variable
-            ray_template_name = os.environ.get("NEMO_RUN_SLURM_RAY_TEMPLATE", "ray.sub.j2")
+            # Use Ray template from executor configuration
+            ray_template_name = executor.ray_template
             req = SlurmRayRequest(
                 name=app.roles[0].name,
                 launch_cmd=["sbatch", "--requeue", "--parsable"],


### PR DESCRIPTION
eg: `executor.ray_template = "ray_enroot.sh.j2"`