### PR TITLE
docs: bump project.json and versions1.json to 0.9.0

### DIFF
--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "NeMo-Run", "version": "nightly"}
+{"name": "NeMo-Run", "version": "0.9.0"}

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,8 +4,12 @@
         "url": "http://docs.nvidia.com/nemo/run/nightly/"
     },
     {
-        "name": "0.8.0 (latest)",
+        "name": "0.9.0 (latest)",
         "preferred": true,
+        "version": "0.9.0",
+        "url": "http://docs.nvidia.com/nemo/run/0.9.0"
+    },
+    {
         "version": "0.8.0",
         "url": "http://docs.nvidia.com/nemo/run/0.8.0"
     },


### PR DESCRIPTION
## Summary

- `project.json`: version `nightly` → `0.9.0`
- `versions1.json`: adds `0.9.0 (latest)`, demotes `0.8.0` to plain versioned entry

## Before / After

**`project.json` before:**
```json
{"name": "NeMo-Run", "version": "nightly"}
```
**`project.json` after:**
```json
{"name": "NeMo-Run", "version": "0.9.0"}
```

**`versions1.json` before:**
```json
{ "name": "0.8.0 (latest)", "preferred": true, "version": "0.8.0", "url": ".../run/0.8.0" }
```
**`versions1.json` after:**
```json
{ "name": "0.9.0 (latest)", "preferred": true, "version": "0.9.0", "url": ".../run/0.9.0" },
{ "version": "0.8.0", "url": ".../run/0.8.0" }
```