### PR TITLE
[docs] ci: fix release version to 0.9.0 in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ sys.path.append(str(Path("../../examples").resolve()))
 project = "NeMo-Run"
 copyright = "2026, NVIDIA"
 author = "NVIDIA"
-release = "nightly"
+release = "0.9.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
## Summary

Fixes `release = "nightly"` → `"0.9.0"` in `docs/conf.py` so the Sphinx version picker correctly highlights **0.9.0** as the current version instead of "nightly".

Same fix as NVIDIA/Megatron-LM@911bc4c128.