### PR TITLE
docs: Fix docs version picker

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -7,19 +7,19 @@
         "name": "0.10.0 (latest)",
         "preferred": true,
         "version": "0.10.0",
-        "url": "http://docs.nvidia.com/nemo/run/latest"
+        "url": "http://docs.nvidia.com/nemo/run/latest/"
     },
     {
         "name": "0.9.0",
         "version": "0.9.0",
-        "url": "http://docs.nvidia.com/nemo/run/0.9.0"
+        "url": "http://docs.nvidia.com/nemo/run/0.9.0/"
     },
     {
         "version": "0.8.0",
-        "url": "http://docs.nvidia.com/nemo/run/0.8.0"
+        "url": "http://docs.nvidia.com/nemo/run/0.8.0/"
     },
     {
         "version": "0.5.0",
-        "url": "http://docs.nvidia.com/nemo/run/0.5.0"
+        "url": "http://docs.nvidia.com/nemo/run/0.5.0/"
     }
 ]


### PR DESCRIPTION
docs: Fix docs version picker

It needs the trailing slash for them to work.