### PR TITLE
ci: Fix docs github ref

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -79,6 +79,8 @@ on:
 jobs:
   build-docs:
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.67.0
+    with:
+      ref: ${{ inputs.github-ref }}
 
   publish-docs:
     runs-on: ubuntu-latest

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,17 +4,22 @@
         "url": "http://docs.nvidia.com/nemo/run/nightly/"
     },
     {
-        "name": "0.9.0 (latest)",
+        "name": "0.10.0 (latest)",
         "preferred": true,
+        "version": "0.10.0",
+        "url": "http://docs.nvidia.com/nemo/run/latest/"
+    },
+    {
+        "name": "0.9.0",
         "version": "0.9.0",
-        "url": "http://docs.nvidia.com/nemo/run/0.9.0"
+        "url": "http://docs.nvidia.com/nemo/run/0.9.0/"
     },
     {
         "version": "0.8.0",
-        "url": "http://docs.nvidia.com/nemo/run/0.8.0"
+        "url": "http://docs.nvidia.com/nemo/run/0.8.0/"
     },
     {
         "version": "0.5.0",
-        "url": "http://docs.nvidia.com/nemo/run/0.5.0"
+        "url": "http://docs.nvidia.com/nemo/run/0.5.0/"
     }
 ]


### PR DESCRIPTION
ci: Fix docs github ref

* Fix docs version picker on main branch to match latest release branch
* Ensure github ref is passed to docs build step