### PR TITLE
fix: use nanosecond experiment timestamps

### DIFF
--- a/nemo_run/run/experiment.py
+++ b/nemo_run/run/experiment.py
@@ -333,7 +333,7 @@ nemo experiment cancel {exp_id} 0
             assert id, "Cannot reconstruct an experiment without id."
 
         self._title = title
-        self._id = id or f"{title}_{int(time.time())}"
+        self._id = id or f"{title}_{time.time_ns()}"
         self._enable_goodbye_message = enable_goodbye_message
         self._threadpool_workers = threadpool_workers
         self._skip_status_at_exit = skip_status_at_exit
@@ -1068,7 +1068,7 @@ For more information about `run.Config` and `run.Partial`, please refer to https
             return self
 
         old_id, old_exp_dir, old_launched = self._id, self._exp_dir, self._launched
-        self._id = f"{self._title}_{int(time.time())}"
+        self._id = f"{self._title}_{time.time_ns()}"
         self._exp_dir = os.path.join(get_nemorun_home(), "experiments", self._title, self._id)
         self._launched = False
         self._live_progress = None

--- a/test/run/test_experiment.py
+++ b/test/run/test_experiment.py
@@ -82,6 +82,18 @@ def test_experiment_creation(temp_dir):
     assert isinstance(exp.executor, LocalExecutor)
 
 
+def test_experiment_creation_uses_nanosecond_timestamp(temp_dir):
+    timestamp_ns = 1_753_041_987_123_456_789
+
+    with patch("nemo_run.run.experiment.time.time_ns", return_value=timestamp_ns):
+        exp = Experiment("test-exp")
+
+    assert exp._id == f"test-exp_{timestamp_ns}"
+    assert exp._exp_dir == os.path.join(
+        temp_dir, "experiments", "test-exp", f"test-exp_{timestamp_ns}"
+    )
+
+
 def test_experiment_with_custom_id(temp_dir):
     """Test creating an experiment with a custom id."""
     exp = Experiment("test-exp", id="custom-id")
@@ -343,6 +355,22 @@ def test_reset_not_run_experiment(temp_dir):
                 f"[bold magenta]Experiment {exp._id} has not run yet, skipping reset..."
             )
             assert reset_exp is exp  # The implementation returns self now
+
+
+def test_reset_uses_nanosecond_timestamp(temp_dir):
+    timestamp_ns = 1_753_041_987_987_654_321
+    exp = Experiment("test-exp", id="test-exp_original")
+    exp._prepare()
+    Path(os.path.join(exp._exp_dir, Experiment._DONE_FILE)).touch()
+
+    with patch("nemo_run.run.experiment.time.time_ns", return_value=timestamp_ns):
+        reset_exp = exp.reset()
+
+    assert reset_exp is exp
+    assert exp._id == f"test-exp_{timestamp_ns}"
+    assert exp._exp_dir == os.path.join(
+        temp_dir, "experiments", "test-exp", f"test-exp_{timestamp_ns}"
+    )
 
 
 @patch("nemo_run.run.experiment.get_runner")


### PR DESCRIPTION
Reduce experiment directory collisions by using time_ns for generated experiment IDs.

We've run into a race condition a few times with DGXC benchmarks where users will try and launch multiple instance of the same experiment in parallel to overcome the slow nemo-run submit times. As the current timestamp is second based, and the folder is not created right after it's checked it's possible for:

1.  Two experiments to share the exact same folder
2. The first experiment to launch and the second to get a folder exist error.

This fix doesn't address the underlaying race condition, but should reduce the frequency and is also a necessary step if we can get nemo-run submissions to be sub-second.