### PR TITLE
fix: publish-docs input is ignored when set to false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       app-id: ${{ vars.BOT_ID }}
       packaging: setuptools
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
-      publish-docs: ${{ inputs.publish-docs || true }}
+      publish-docs: ${{ inputs.publish-docs == true }}
       docs-target-path: nemo/run
       restrict-to-admins: true
     secrets: inherit  # pragma: allowlist secret

--- a/tests/test_release_publish_docs.py
+++ b/tests/test_release_publish_docs.py
@@ -1,0 +1,16 @@
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestReleaseWorkflow(unittest.TestCase):
+    def test_publish_docs_respects_false_input(self):
+        workflow = REPO_ROOT / ".github" / "workflows" / "release.yml"
+        text = workflow.read_text()
+        match = re.search(r"^\s+publish-docs:\s*(.+)$", text, re.MULTILINE)
+        self.assertIsNotNone(match)
+        self.assertNotIn("|| true", match.group(1),
+                         "publish-docs always evaluates to true; false input is ignored")
+


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/release.yml`: publish-docs input is ignored when set to false.

## Changes
- `.github/workflows/release.yml`: publish-docs input is ignored when set to false.

## Details
```diff
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,1 +1,1 @@
-      publish-docs: ${{ inputs.publish-docs || true }}
+      publish-docs: ${{ inputs.publish-docs == true }}
```

## Tests
- `tests/test_release_publish_docs.py`

```diff
--- /dev/null
+++ b/tests/test_release_publish_docs.py
@@ -0,0 +1,16 @@
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestReleaseWorkflow(unittest.TestCase):
+    def test_publish_docs_respects_false_input(self):
+        workflow = REPO_ROOT / ".github" / "workflows" / "release.yml"
+        text = workflow.read_text()
+        match = re.search(r"^\s+publish-docs:\s*(.+)$", text, re.MULTILINE)
+        self.assertIsNotNone(match)
+        self.assertNotIn("|| true", match.group(1),
+                         "publish-docs always evaluates to true; false input is ignored")
+
+
+if __name__ == "__main__":
+    unittest.main()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).