### PR TITLE
fix: publish-docs toggle forced true so false input is ignored

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       app-id: ${{ vars.BOT_ID }}
       packaging: setuptools
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
-      publish-docs: ${{ github.event_name == 'workflow_dispatch' ? inputs.publish-docs : true }}
+      publish-docs: ${{ github.event_name != 'workflow_dispatch' || inputs.publish-docs }}
       docs-target-path: nemo/run
       restrict-to-admins: true
     secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       app-id: ${{ vars.BOT_ID }}
       packaging: setuptools
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
-      publish-docs: ${{ inputs.publish-docs || true }}
+      publish-docs: ${{ github.event_name == 'workflow_dispatch' ? inputs.publish-docs : true }}
       docs-target-path: nemo/run
       restrict-to-admins: true
     secrets: inherit  # pragma: allowlist secret

--- a/tests/test_release_publish_docs.py
+++ b/tests/test_release_publish_docs.py
@@ -1,0 +1,12 @@
+"""Regression test for release.yml publish-docs toggle."""
+import pathlib
+
+RELEASE_YML = pathlib.Path(".github/workflows/release.yml")
+
+
+def test_publish_docs_input_allows_false():
+    content = RELEASE_YML.read_text()
+    forbidden = "publish-docs: ${{ inputs.publish-docs || true }}"
+    assert forbidden not in content, (
+        "publish-docs input is forced to true and cannot be disabled"
+    )


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/release.yml`: publish-docs toggle forced true so false input is ignored.

## Changes
- `.github/workflows/release.yml`: publish-docs toggle forced true so false input is ignored.

## Details
```diff
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,1 +1,1 @@
-      publish-docs: ${{ inputs.publish-docs || true }}
+      publish-docs: ${{ github.event_name == 'workflow_dispatch' ? inputs.publish-docs : true }}
```

## Tests
- `tests/test_release_publish_docs.py`

```diff
diff --git a/tests/test_release_publish_docs.py b/tests/test_release_publish_docs.py
new file mode 100644
index 0000000..e69de29
--- /dev/null
+++ b/tests/test_release_publish_docs.py
@@ -0,0 +1,12 @@
+"""Regression test for release.yml publish-docs toggle."""
+import pathlib
+
+RELEASE_YML = pathlib.Path(".github/workflows/release.yml")
+
+
+def test_publish_docs_input_allows_false():
+    content = RELEASE_YML.read_text()
+    forbidden = "publish-docs: ${{ inputs.publish-docs || true }}"
+    assert forbidden not in content, (
+        "publish-docs input is forced to true and cannot be disabled"
+    )
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).