### PR TITLE
fix: nightly tag job lacks contents:write permission

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
     name: Run Tests and Create Nightly Tag
     runs-on: ubuntu-latest
     needs: [format, lint, test]
+    permissions:
+      contents: write
     steps:
         - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 

--- a/tests/test_nightly_permissions.py
+++ b/tests/test_nightly_permissions.py
@@ -1,0 +1,14 @@
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestNightlyWorkflow(unittest.TestCase):
+    def test_tag_job_has_contents_write(self):
+        workflow = REPO_ROOT / ".github" / "workflows" / "nightly.yml"
+        text = workflow.read_text()
+        self.assertIn("contents: write", text,
+                      "nightly workflow needs contents:write to create/update the nightly tag")
+
+


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/nightly.yml`: nightly tag job lacks contents:write permission.

## Changes
- `.github/workflows/nightly.yml`: nightly tag job lacks contents:write permission.

## Details
```diff
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,7 @@
-  tag:
-    name: Run Tests and Create Nightly Tag
-    runs-on: ubuntu-latest
-    needs: [format, lint, test]
-    steps:
+  tag:
+    name: Run Tests and Create Nightly Tag
+    runs-on: ubuntu-latest
+    needs: [format, lint, test]
+    permissions:
+      contents: write
+    steps:
```

## Tests
- `tests/test_nightly_permissions.py`

```diff
--- /dev/null
+++ b/tests/test_nightly_permissions.py
@@ -0,0 +1,14 @@
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestNightlyWorkflow(unittest.TestCase):
+    def test_tag_job_has_contents_write(self):
+        workflow = REPO_ROOT / ".github" / "workflows" / "nightly.yml"
+        text = workflow.read_text()
+        self.assertIn("contents: write", text,
+                      "nightly workflow needs contents:write to create/update the nightly tag")
+
+
+if __name__ == "__main__":
+    unittest.main()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).