### PR TITLE
fix: cherry-pick workflow triggers on main instead of release branches

### DIFF
--- a/.github/workflows/cherry-pick-release-commit.yml
+++ b/.github/workflows/cherry-pick-release-commit.yml
@@ -3,7 +3,8 @@ name: Create PR to main with cherry-pick from release
 on:
   push:
     branches:
-      - main
+      - "[rv][0-9].[0-9].[0-9]"
+      - "[rv][0-9].[0-9].[0-9]rc[0-9]"
 
 jobs:
   cherry-pick:

--- a/tests/test_cherry_pick_trigger.py
+++ b/tests/test_cherry_pick_trigger.py
@@ -1,0 +1,14 @@
+"""Regression test for cherry-pick workflow trigger."""
+import pathlib
+
+CHERRY_YML = pathlib.Path(".github/workflows/cherry-pick-release-commit.yml")
+
+
+def test_cherry_pick_triggers_on_release_branches():
+    content = CHERRY_YML.read_text()
+    assert "branches:\n      - main" not in content, (
+        "cherry-pick workflow should not trigger only on main"
+    )
+    assert "[rv]" in content, (
+        "cherry-pick workflow should trigger on release branches"
+    )


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/cherry-pick-release-commit.yml`: cherry-pick workflow triggers on main instead of release branches.

## Changes
- `.github/workflows/cherry-pick-release-commit.yml`: cherry-pick workflow triggers on main instead of release branches.

## Details
```diff
--- a/.github/workflows/cherry-pick-release-commit.yml
+++ b/.github/workflows/cherry-pick-release-commit.yml
@@ -1,4 +1,5 @@
-on:
-  push:
-    branches:
-      - main
+on:
+  push:
+    branches:
+      - "[rv][0-9].[0-9].[0-9]"
+      - "[rv][0-9].[0-9].[0-9]rc[0-9]"
```

## Tests
- `tests/test_cherry_pick_trigger.py`

```diff
diff --git a/tests/test_cherry_pick_trigger.py b/tests/test_cherry_pick_trigger.py
new file mode 100644
index 0000000..e69de29
--- /dev/null
+++ b/tests/test_cherry_pick_trigger.py
@@ -0,0 +1,14 @@
+"""Regression test for cherry-pick workflow trigger."""
+import pathlib
+
+CHERRY_YML = pathlib.Path(".github/workflows/cherry-pick-release-commit.yml")
+
+
+def test_cherry_pick_triggers_on_release_branches():
+    content = CHERRY_YML.read_text()
+    assert "branches:\n      - main" not in content, (
+        "cherry-pick workflow should not trigger only on main"
+    )
+    assert "[rv]" in content, (
+        "cherry-pick workflow should trigger on release branches"
+    )
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).